### PR TITLE
Use enums instead of union types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,11 +72,11 @@
 
     "@types/lodash": ["@types/lodash@4.17.15", "", {}, "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw=="],
 
-    "@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+    "@types/node": ["@types/node@22.13.4", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
-    "ansi-regex": ["ansi-regex@6.0.1", "", {}, "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="],
+    "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
@@ -94,7 +94,7 @@
 
     "deckstrings": ["deckstrings@3.1.2", "", {}, "sha512-u495/2wXLJJwusL27Tp8d5srTMg7H5ZZxhnvLG7ZYeVxQOpKaCTHx/JTLElG6j/jZX5QUFh6/nOmqoGnQtSFKw=="],
 
-    "generate-changelog": ["generate-changelog@1.8.0", "", { "dependencies": { "bluebird": "^3.0.6", "commander": "^2.9.0", "github-url-from-git": "^1.4.0" }, "bin": { "generate-changelog": "./bin/generate", "changelog": "./bin/generate" } }, "sha512-msgpxeB75Ziyg3wGsZuPNl7c5RxChMKmYcAX5obnhUow90dBZW3nLic6nxGtst7Bpx453oS6zAIHcX7F3QVasw=="],
+    "generate-changelog": ["generate-changelog@1.8.0", "", { "dependencies": { "bluebird": "^3.0.6", "commander": "^2.9.0", "github-url-from-git": "^1.4.0" }, "bin": { "changelog": "./bin/generate", "generate-changelog": "./bin/generate" } }, "sha512-msgpxeB75Ziyg3wGsZuPNl7c5RxChMKmYcAX5obnhUow90dBZW3nLic6nxGtst7Bpx453oS6zAIHcX7F3QVasw=="],
 
     "github-url-from-git": ["github-url-from-git@1.5.0", "", {}, "sha512-WWOec4aRI7YAykQ9+BHmzjyNlkfJFG8QLXnDTsLz/kZefq7qkzdfo4p6fkYYMIq1aj+gZcQs/1HQhQh3DPPxlQ=="],
 
@@ -105,9 +105,5 @@
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "@types/ws/@types/node": ["@types/node@22.10.0", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA=="],
-
-    "bun-types/@types/node": ["@types/node@22.10.0", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA=="],
   }
 }

--- a/cards/1-sheep.ts
+++ b/cards/1-sheep.ts
@@ -1,20 +1,26 @@
 // Created by Hand (before the Card Creator Existed)
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Sheep",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 1,
 
 	attack: 1,
 	health: 1,
-	tribe: "Beast",
+	tribe: MinionTribe.Beast,
 };

--- a/cards/2-the-coin.ts
+++ b/cards/2-the-coin.ts
@@ -1,20 +1,27 @@
 // Created by Hand (before the Card Creator Existed)
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "The Coin",
 	text: "Gain 1 Mana Crystal this turn only.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 2,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Gain 1 Mana Crystal this turn only.
@@ -30,13 +37,13 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// Assert 5->6
 		owner.mana = 5;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.mana, 6);
 
 		// Assert 10->10
 		owner.mana = 10;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.mana, 10);
 	},

--- a/cards/3-plant.ts
+++ b/cards/3-plant.ts
@@ -3,20 +3,26 @@
 // This is used in Adapt
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Plant",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 3,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/85-jade-golem.ts
+++ b/cards/85-jade-golem.ts
@@ -1,20 +1,26 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Jade Golem",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 85,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/Classes/Druid/Collectible/Heroes/5-Cost/89-wildheart-guff.ts
+++ b/cards/Classes/Druid/Collectible/Heroes/5-Cost/89-wildheart-guff.ts
@@ -1,15 +1,15 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Wildheart Guff",
 	text: "<b>Battlecry:</b> Set your maximum Mana to 20. Gain an empty Mana Crystal. Draw a card.",
 	cost: 5,
-	type: "Hero",
-	classes: ["Druid"],
-	rarity: "Legendary",
+	type: Type.Hero,
+	classes: [Class.Druid],
+	rarity: Rarity.Legendary,
 	collectible: true,
 	tags: [],
 	id: 89,
@@ -31,7 +31,7 @@ export const blueprint: Blueprint = {
 		// Update if changing the default max mana.
 		assert.equal(owner.maxMana, 10);
 
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		assert.equal(owner.maxMana, 20);
 		assert.equal(owner.emptyMana, emptyMana + 1);

--- a/cards/Classes/Druid/Collectible/Spells/0-Cost/93-aquatic-form.ts
+++ b/cards/Classes/Druid/Collectible/Spells/0-Cost/93-aquatic-form.ts
@@ -1,20 +1,27 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Aquatic Form",
 	text: "<b>Dredge</b>. If you have the Mana to play the card this turn, draw it.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Rare",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Rare,
 	collectible: true,
 	tags: [],
 	id: 93,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Dredge. If you have the Mana to play the card this turn, draw it.
@@ -35,13 +42,13 @@ export const blueprint: Blueprint = {
 		// Shouldn't draw any cards
 		owner.mana = -1;
 
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 		assert.equal(owner.hand.length, handSize);
 
 		// Should draw a card
 		owner.mana = 10;
 
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 		assert.equal(owner.hand.length, handSize + 1);
 	},
 };

--- a/cards/Classes/Druid/Collectible/Spells/1-Cost/101-floops-glorious-gloop.ts
+++ b/cards/Classes/Druid/Collectible/Spells/1-Cost/101-floops-glorious-gloop.ts
@@ -1,35 +1,47 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Event,
+	EventListenerMessage,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Floop's Glorious Gloop",
 	text: "Whenever a minion dies this turn, gain 1 Mana Crystal this turn only.",
 	cost: 1,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Legendary",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Legendary,
 	collectible: true,
 	tags: [],
 	id: 101,
 
-	spellSchool: "Nature",
+	spellSchool: SpellSchool.Nature,
 
 	async cast(owner, self) {
 		// Whenever a minion dies this turn, gain 1 Mana Crystal this turn only.
 		const destroy = game.event.addListener(
-			"KillCard",
+			Event.KillCard,
 			async () => {
 				// Gain 1 Mana Crystal
 				owner.refreshMana(1, owner.maxMana);
 
-				return true;
+				return EventListenerMessage.Success;
 			},
 			-1,
 		);
 
-		game.event.addListener("EndTurn", async () => destroy());
+		game.event.addListener(Event.EndTurn, async () => {
+			destroy();
+
+			return EventListenerMessage.Destroy;
+		});
 	},
 
 	async test(owner, self) {

--- a/cards/Classes/Druid/Collectible/Spells/1-Cost/84-jade-idol.ts
+++ b/cards/Classes/Druid/Collectible/Spells/1-Cost/84-jade-idol.ts
@@ -1,20 +1,27 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Jade Idol",
 	text: "<b>Choose One -</b> Summon a <b>Jade Golem</b>; or Shuffle 3 copies of this card into your deck.",
 	cost: 1,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Rare",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Rare,
 	collectible: true,
 	tags: [],
 	id: 84,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Choose One - Summon a Jade Golem; or Shuffle 3 copies of this card into your deck.
@@ -43,14 +50,14 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// Summon a Jade Golem
 		owner.inputQueue = ["1"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// There should be a jade golem
 		assert.ok(owner.board.some((card) => card.id === game.cardIds.jadeGolem85));
 
 		// Shuffle 3 copies
 		owner.inputQueue = ["2"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// There should be 3 copies of this card in the player's deck
 		assert.equal(owner.deck.filter((card) => card.id === self.id).length, 3);

--- a/cards/Classes/Druid/Collectible/Spells/2-Cost/90-moonlit-guidance.ts
+++ b/cards/Classes/Druid/Collectible/Spells/2-Cost/90-moonlit-guidance.ts
@@ -46,7 +46,7 @@ export const blueprint: Blueprint = {
 				const value = _unknownValue as EventValue<Event.PlayCard>;
 
 				if (value !== card) {
-					return EventListenerMessage.Ignore;
+					return EventListenerMessage.Skip;
 				}
 
 				await owner.drawSpecific(original);

--- a/cards/Classes/Druid/Collectible/Spells/2-Cost/90-moonlit-guidance.ts
+++ b/cards/Classes/Druid/Collectible/Spells/2-Cost/90-moonlit-guidance.ts
@@ -1,20 +1,29 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Event,
+	EventListenerMessage,
+	type EventValue,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Moonlit Guidance",
 	text: "<b>Discover</b> a copy of a card in your deck. If you play it this turn, draw the original.",
 	cost: 2,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Rare",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Rare,
 	collectible: true,
 	tags: [],
 	id: 90,
 
-	spellSchool: "Arcane",
+	spellSchool: SpellSchool.Arcane,
 
 	async cast(owner, self) {
 		// Discover a copy of a card in your deck. If you play it this turn, draw the original.
@@ -32,21 +41,25 @@ export const blueprint: Blueprint = {
 
 		// Wait for the player to play the card
 		const destroy = game.event.addListener(
-			"PlayCard",
+			Event.PlayCard,
 			async (_unknownValue, eventPlayer) => {
-				const value = _unknownValue as EventValue<"PlayCard">;
+				const value = _unknownValue as EventValue<Event.PlayCard>;
 
 				if (value !== card) {
-					return false;
+					return EventListenerMessage.Ignore;
 				}
 
 				await owner.drawSpecific(original);
-				return true;
+				return EventListenerMessage.Success;
 			},
 		);
 
 		// Destroy the event listener when the turn ends
-		game.event.addListener("EndTurn", async () => destroy());
+		game.event.addListener(Event.EndTurn, async () => {
+			destroy();
+
+			return EventListenerMessage.Destroy;
+		});
 	},
 
 	async test(owner, self) {

--- a/cards/Classes/Druid/Collectible/Spells/2-Cost/91-dew-process.ts
+++ b/cards/Classes/Druid/Collectible/Spells/2-Cost/91-dew-process.ts
@@ -1,28 +1,37 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Event,
+	EventListenerMessage,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Dew Process",
 	text: "For the rest of the game, players draw an extra card at the start of their turn.",
 	cost: 2,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Rare",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Rare,
 	collectible: true,
 	tags: [],
 	id: 91,
 
-	spellSchool: "Nature",
+	spellSchool: SpellSchool.Nature,
 
 	async cast(owner, self) {
 		// For the rest of the game, players draw an extra card at the start of their turn.
 		game.event.addListener(
-			"StartTurn",
+			Event.StartTurn,
 			async (_unknownValue, eventPlayer) => {
 				await eventPlayer.drawCards(1);
-				return true;
+				return EventListenerMessage.Success;
 			},
 			-1,
 		);
@@ -38,7 +47,7 @@ export const blueprint: Blueprint = {
 		// Increment handSize by 1 so that we can do handSize + 2
 		assert.equal(owner.hand.length, ++handSize);
 
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		await game.endTurn();
 		await game.endTurn();

--- a/cards/Classes/Druid/Collectible/Spells/2-Cost/92-invigorate.ts
+++ b/cards/Classes/Druid/Collectible/Spells/2-Cost/92-invigorate.ts
@@ -1,20 +1,27 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Invigorate",
 	text: "<b>Choose One -</b> Gain an empty Mana Crystal; or Draw a card.",
 	cost: 2,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Rare",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Rare,
 	collectible: true,
 	tags: [],
 	id: 92,
 
-	spellSchool: "Nature",
+	spellSchool: SpellSchool.Nature,
 
 	async cast(owner, self) {
 		// Choose One - Gain an empty Mana Crystal; or Draw a card.
@@ -42,7 +49,7 @@ export const blueprint: Blueprint = {
 		const { emptyMana } = owner;
 
 		owner.inputQueue = ["1"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.emptyMana, emptyMana + 1);
 
@@ -50,7 +57,7 @@ export const blueprint: Blueprint = {
 		const handSize = owner.hand.length;
 
 		owner.inputQueue = ["2"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.hand.length, handSize + 1);
 	},

--- a/cards/Classes/Druid/Collectible/Spells/3-Cost/94-frost-lotus-seedling.ts
+++ b/cards/Classes/Druid/Collectible/Spells/3-Cost/94-frost-lotus-seedling.ts
@@ -1,20 +1,26 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Frost Lotus Seedling",
 	text: "{placeholder}",
 	cost: 3,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Rare",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Rare,
 	collectible: true,
 	tags: [],
 	id: 94,
 
-	spellSchool: "Nature",
+	spellSchool: SpellSchool.Nature,
 
 	async create(owner, self) {
 		// Initialize storage

--- a/cards/Classes/Druid/Collectible/Spells/4-Cost/82-poison-seeds.ts
+++ b/cards/Classes/Druid/Collectible/Spells/4-Cost/82-poison-seeds.ts
@@ -2,20 +2,27 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Poison Seeds",
 	text: "Destroy all minions and summon 2/2 Treants to replace them.",
 	cost: 4,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Common",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Common,
 	collectible: true,
 	tags: [],
 	id: 82,
 
-	spellSchool: "Nature",
+	spellSchool: SpellSchool.Nature,
 
 	async cast(owner, self) {
 		// Destroy all minions and summon 2/2 Treants to replace them.
@@ -39,7 +46,7 @@ export const blueprint: Blueprint = {
 		}
 
 		// Replace with Treants
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// Check if every card is a Treant
 		const board = owner.board;

--- a/cards/Classes/Druid/Collectible/Spells/4-Cost/86-branching-paths.ts
+++ b/cards/Classes/Druid/Collectible/Spells/4-Cost/86-branching-paths.ts
@@ -2,20 +2,27 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Branching Paths",
 	text: "<b>Choose Twice -</b> Draw a card; Give your minions +1 Attack; Gain 6 Armor.",
 	cost: 4,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Epic",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Epic,
 	collectible: true,
 	tags: [],
 	id: 86,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Choose Twice - Draw a card; Give your minions +1 Attack; Gain 6 Armor.
@@ -58,14 +65,14 @@ export const blueprint: Blueprint = {
 
 		// Test 'Draw a Card', and 'Give your minions +1 Attack'.
 		owner.inputQueue = ["1", "2"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.hand.length, handSize + 1);
 		assert.equal(sheep.attack, 2);
 
 		// Test '+1 Attack', and 'Gain 6 Armor'.
 		owner.inputQueue = ["2", "3"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(sheep.attack, 3);
 		assert.equal(owner.armor, 6);

--- a/cards/Classes/Druid/Collectible/Spells/4-Cost/87-oaken-summons.ts
+++ b/cards/Classes/Druid/Collectible/Spells/4-Cost/87-oaken-summons.ts
@@ -1,20 +1,27 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Oaken Summons",
 	text: "Gain 6 Armor. <b>Recruit</b> a minion that costs (4) or less.",
 	cost: 4,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Common",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Common,
 	collectible: true,
 	tags: [],
 	id: 87,
 
-	spellSchool: "Nature",
+	spellSchool: SpellSchool.Nature,
 
 	async cast(owner, self) {
 		// Gain 6 Armor. Recruit a minion that costs (4) or less.
@@ -24,7 +31,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		for (let index = 1; index <= 10; index++) {
-			await self.activate("cast");
+			await self.activate(Ability.Cast);
 
 			// Check if the armor is correct
 			assert.equal(owner.armor, 6 * index);
@@ -33,7 +40,9 @@ export const blueprint: Blueprint = {
 			assert.ok(
 				owner.board.some(
 					(card) =>
-						card.cost <= 4 && card.type === "Minion" && card.uuid !== self.uuid,
+						card.cost <= 4 &&
+						card.type === Type.Minion &&
+						card.uuid !== self.uuid,
 				),
 			);
 

--- a/cards/Classes/Druid/Collectible/Spells/5-Cost/97-flipper-friends.ts
+++ b/cards/Classes/Druid/Collectible/Spells/5-Cost/97-flipper-friends.ts
@@ -2,20 +2,27 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Flipper Friends",
 	text: "<b>Choose One</b> - Summon a 6/6 Orca with <b>Taunt</b>; or six 1/1 Otters with <b>Rush</b>.",
 	cost: 5,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Common",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Common,
 	collectible: true,
 	tags: [],
 	id: 97,
 
-	spellSchool: "Nature",
+	spellSchool: SpellSchool.Nature,
 
 	async cast(owner, self) {
 		// Choose One - Summon a 6/6 Orca with Taunt; or six 1/1 Otters with Rush.
@@ -45,7 +52,7 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// Summon a 6/6 Orca with Taunt
 		owner.inputQueue = ["1"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// There should be 1 Orca on the board
 		assert.equal(
@@ -58,7 +65,7 @@ export const blueprint: Blueprint = {
 
 		// Summon six 1/1 Otters with Rush
 		owner.inputQueue = ["2"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// There should be 6 Otters on the board
 		assert.equal(

--- a/cards/Classes/Druid/Collectible/Spells/7-Cost/100-scale-of-onyxia.ts
+++ b/cards/Classes/Druid/Collectible/Spells/7-Cost/100-scale-of-onyxia.ts
@@ -2,20 +2,27 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Scale of Onyxia",
 	text: "Fill your board with 2/1 Whelps with <b>Rush</b>.",
 	cost: 7,
-	type: "Spell",
-	classes: ["Druid"],
-	rarity: "Common",
+	type: Type.Spell,
+	classes: [Class.Druid],
+	rarity: Rarity.Common,
 	collectible: true,
 	tags: [],
 	id: 100,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Fill your board with 2/1 Whelps with Rush.
@@ -29,7 +36,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		assert.equal(owner.board.length, 0);
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// Check if the board has been filled
 		assert.equal(owner.board.length, game.config.general.maxBoardSpace);

--- a/cards/Classes/Druid/Uncollectible/Heropowers/2-Cost/113-nurture.ts
+++ b/cards/Classes/Druid/Uncollectible/Heropowers/2-Cost/113-nurture.ts
@@ -1,15 +1,15 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Nurture",
 	text: "<b>Choose One -</b> Draw a card; or Gain an empty Mana Crystal.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Druid"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Druid],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 113,
@@ -40,7 +40,7 @@ export const blueprint: Blueprint = {
 		const handSize = owner.hand.length;
 
 		owner.inputQueue = ["1"];
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		assert.equal(owner.hand.length, handSize + 1);
 
@@ -48,7 +48,7 @@ export const blueprint: Blueprint = {
 		const { emptyMana } = owner;
 
 		owner.inputQueue = ["2"];
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		assert.equal(owner.emptyMana, emptyMana + 1);
 	},

--- a/cards/Classes/Druid/Uncollectible/Minions/1-Cost/83-treant.ts
+++ b/cards/Classes/Druid/Uncollectible/Minions/1-Cost/83-treant.ts
@@ -1,19 +1,25 @@
 // Created by the Vanilla Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Treant",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Druid"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Druid],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 83,
 
 	attack: 2,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/Classes/Druid/Uncollectible/Minions/1-Cost/95-otter.ts
+++ b/cards/Classes/Druid/Uncollectible/Minions/1-Cost/95-otter.ts
@@ -2,25 +2,32 @@
 
 // This is the Flipper Friends Otter card
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Otter",
 	text: "<b>Rush</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Druid"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Druid],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 95,
 
 	attack: 1,
 	health: 1,
-	tribe: "Beast",
+	tribe: MinionTribe.Beast,
 
 	async create(owner, self) {
 		// Add additional fields here
-		self.addKeyword("Rush");
+		self.addKeyword(Keyword.Rush);
 	},
 };

--- a/cards/Classes/Druid/Uncollectible/Minions/6-Cost/96-orca.ts
+++ b/cards/Classes/Druid/Uncollectible/Minions/6-Cost/96-orca.ts
@@ -2,25 +2,32 @@
 
 // This is the Flipper Friends Orca card
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Orca",
 	text: "<b>Taunt</b>",
 	cost: 6,
-	type: "Minion",
-	classes: ["Druid"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Druid],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 96,
 
 	attack: 6,
 	health: 6,
-	tribe: "Beast",
+	tribe: MinionTribe.Beast,
 
 	async create(owner, self) {
 		// Add additional fields here
-		self.addKeyword("Taunt");
+		self.addKeyword(Keyword.Taunt);
 	},
 };

--- a/cards/Classes/Mage/Collectible/Spells/10-Cost/105-pyroblast.ts
+++ b/cards/Classes/Mage/Collectible/Spells/10-Cost/105-pyroblast.ts
@@ -2,28 +2,37 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	TargetAlignment,
+	TargetClass,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Pyroblast",
 	text: "Deal $10 damage.",
 	cost: 10,
-	type: "Spell",
-	classes: ["Mage"],
-	rarity: "Epic",
+	type: Type.Spell,
+	classes: [Class.Mage],
+	rarity: Rarity.Epic,
 	collectible: true,
 	tags: [],
 	id: 105,
 
-	spellSchool: "Fire",
+	spellSchool: SpellSchool.Fire,
 
 	async cast(owner, self) {
 		// Deal $10 damage.
 		const target = await game.functions.interact.prompt.target(
 			self.text,
 			self,
-			"any",
-			"any",
+			TargetAlignment.Any,
+			TargetClass.Any,
 		);
 		if (!target) {
 			return Card.REFUND;
@@ -38,7 +47,7 @@ export const blueprint: Blueprint = {
 		owner.forceTarget = owner.getOpponent();
 
 		// If no spellDamage
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 		assert.equal(owner.getOpponent().health, enemyHealth - 10);
 
 		// Reset health
@@ -47,7 +56,7 @@ export const blueprint: Blueprint = {
 		// If 5 spellDamage
 		owner.spellDamage = 5;
 
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 		assert.equal(owner.getOpponent().health, enemyHealth - 15);
 	},
 };

--- a/cards/Classes/Neutral/Collectible/Locations/7-Cost/102-prison-of-yogg-saron.ts
+++ b/cards/Classes/Neutral/Collectible/Locations/7-Cost/102-prison-of-yogg-saron.ts
@@ -2,15 +2,23 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	TargetAlignment,
+	TargetClass,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Prison of Yogg-Saron",
 	text: "Choose a character. Cast 4 random spells <i>(targeting it if possible)</i>.",
 	cost: 7,
-	type: "Location",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Location,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: true,
 	tags: [],
 	id: 102,
@@ -23,8 +31,8 @@ export const blueprint: Blueprint = {
 		const target = await game.functions.interact.prompt.target(
 			self.text,
 			self,
-			"any",
-			"any",
+			TargetAlignment.Any,
+			TargetClass.Any,
 		);
 		if (!target) {
 			return Card.REFUND;
@@ -32,7 +40,7 @@ export const blueprint: Blueprint = {
 
 		owner.forceTarget = target;
 
-		const pool = (await Card.all()).filter((card) => card.type === "Spell");
+		const pool = (await Card.all()).filter((card) => card.type === Type.Spell);
 
 		for (let i = 0; i < 4; i++) {
 			const card = await game.lodash.sample(pool)?.imperfectCopy();
@@ -40,7 +48,7 @@ export const blueprint: Blueprint = {
 				continue;
 			}
 
-			await card.activate("cast");
+			await card.activate(Ability.Cast);
 		}
 
 		owner.forceTarget = undefined;

--- a/cards/Classes/Neutral/Collectible/Minions/1-Cost/110-chaotic-tendril.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/1-Cost/110-chaotic-tendril.ts
@@ -2,33 +2,40 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Chaotic Tendril",
 	text: "<b>Battlecry:</b> Cast a random 1-Cost spell. Improve your future Chaotic Tendrils.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Common",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Common,
 	collectible: true,
 	tags: [],
 	id: 110,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Cast a random 1-Cost spell. Improve your future Chaotic Tendrils.
 		const pool = (await Card.all()).filter(
-			(card) => card.type === "Spell" && card.cost === 1,
+			(card) => card.type === Type.Spell && card.cost === 1,
 		);
 
 		const spell = await game.lodash.sample(pool)?.imperfectCopy();
 
 		if (spell) {
-			await spell.activate("cast");
+			await spell.activate(Ability.Cast);
 		}
 
 		// TODO: Improve your future Chaotic Tendrils. #372

--- a/cards/Classes/Neutral/Collectible/Minions/10-Cost/103-yogg-saron-hopes-end.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/10-Cost/103-yogg-saron-hopes-end.ts
@@ -2,33 +2,40 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Yogg-Saron, Hope's End",
 	text: "<b>Battlecry:</b> Cast a random spell for each spell you've cast this game <i>(targets chosen randomly)</i>.",
 	cost: 10,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: true,
 	tags: [],
 	id: 103,
 
 	attack: 7,
 	health: 5,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Cast a random spell for each spell you've cast this game (targets chosen randomly).
 		const amount = game.event.events.PlayCard?.[owner.id].filter(
-			(object) => object[0] instanceof Card && object[0].type === "Spell",
+			(object) => object[0] instanceof Card && object[0].type === Type.Spell,
 		).length;
 		if (!amount) {
 			return;
 		}
 
-		const pool = (await Card.all()).filter((card) => card.type === "Spell");
+		const pool = (await Card.all()).filter((card) => card.type === Type.Spell);
 
 		for (let i = 0; i < amount; i++) {
 			const card = await game.lodash.sample(pool)?.imperfectCopy();
@@ -37,7 +44,7 @@ export const blueprint: Blueprint = {
 				continue;
 			}
 
-			await card.activate("cast");
+			await card.activate(Ability.Cast);
 		}
 	},
 

--- a/cards/Classes/Neutral/Collectible/Minions/10-Cost/104-yogg-saron-master-of-fate.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/10-Cost/104-yogg-saron-master-of-fate.ts
@@ -3,22 +3,32 @@
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
 import { Player } from "@Core/player.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Event,
+	EventListenerMessage,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Yogg-Saron, Master of Fate",
 	text: "<b>Battlecry:</b> If you've cast 10 spells this game, spin the Wheel of Yogg-Saron.{left}",
 	cost: 10,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: true,
 	tags: [],
 	id: 104,
 
 	attack: 7,
 	health: 5,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// If you've cast 10 spells this game, spin the Wheel of Yogg-Saron. ({amount} left!)
@@ -42,8 +52,8 @@ export const blueprint: Blueprint = {
 
 		const pool = await Card.all();
 
-		const minionPool = pool.filter((card) => card.type === "Minion");
-		const spellPool = pool.filter((card) => card.type === "Spell");
+		const minionPool = pool.filter((card) => card.type === Type.Minion);
+		const spellPool = pool.filter((card) => card.type === Type.Spell);
 
 		switch (choice) {
 			case "Curse of Flesh": {
@@ -62,7 +72,7 @@ export const blueprint: Blueprint = {
 						}
 
 						if (player === owner) {
-							card.addKeyword("Rush");
+							card.addKeyword(Keyword.Rush);
 						}
 
 						await player.summon(card);
@@ -102,12 +112,12 @@ export const blueprint: Blueprint = {
 					await owner.addToHand(card);
 				}
 
-				game.event.addListener("EndTurn", async () => {
+				game.event.addListener(Event.EndTurn, async () => {
 					for (const card of owner.hand) {
 						card.removeEnchantment("cost = 0", self);
 					}
 
-					return "destroy";
+					return EventListenerMessage.Destroy;
 				});
 
 				break;
@@ -135,7 +145,7 @@ export const blueprint: Blueprint = {
 					game.cardIds.yoggSaronHopesEnd103,
 					owner,
 				);
-				await oldYogg.activate("battlecry");
+				await oldYogg.activate(Ability.Battlecry);
 
 				break;
 			}
@@ -146,7 +156,7 @@ export const blueprint: Blueprint = {
 
 				while (game.player1.isAlive() && game.player2.isAlive()) {
 					owner.forceTarget = game.functions.util.getRandomTarget();
-					await rod.activate("cast");
+					await rod.activate(Ability.Cast);
 				}
 
 				owner.forceTarget = undefined;
@@ -157,12 +167,12 @@ export const blueprint: Blueprint = {
 			// No default
 		}
 
-		await game.event.broadcast("CardEvent", [self, choice], owner);
+		await game.event.broadcast(Event.CardEvent, [self, choice], owner);
 	},
 
 	async placeholders(owner, self) {
 		const amount = game.event.events.PlayCard?.[owner.id].filter(
-			(object) => object[0] instanceof Card && object[0].type === "Spell",
+			(object) => object[0] instanceof Card && object[0].type === Type.Spell,
 		).length;
 		if (!amount) {
 			return { left: " <i>(10 left!)</i>" };
@@ -177,7 +187,7 @@ export const blueprint: Blueprint = {
 
 	async condition(owner, self) {
 		const amount = game.event.events.PlayCard?.[owner.id].filter(
-			(object) => object[0] instanceof Card && object[0].type === "Spell",
+			(object) => object[0] instanceof Card && object[0].type === Type.Spell,
 		).length;
 		if (!amount) {
 			return false;

--- a/cards/Classes/Neutral/Collectible/Minions/4-Cost/88-injured-marauder.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/4-Cost/88-injured-marauder.ts
@@ -1,26 +1,34 @@
 // Created by the Vanilla Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Injured Marauder",
 	text: "<b>Taunt. Battlecry:</b> Deal 6 damage to this minion.",
 	cost: 4,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Common",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Common,
 	collectible: true,
 	tags: [],
 	id: 88,
 
 	attack: 5,
 	health: 10,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Add additional fields here
-		self.addKeyword("Taunt");
+		self.addKeyword(Keyword.Taunt);
 	},
 
 	async battlecry(owner, self) {
@@ -29,7 +37,7 @@ export const blueprint: Blueprint = {
 	},
 
 	async test(owner, self) {
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 		assert.equal(self.health, 4);
 	},
 };

--- a/cards/Classes/Neutral/Collectible/Minions/4-Cost/98-archmage-vargoth.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/4-Cost/98-archmage-vargoth.ts
@@ -2,22 +2,29 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Archmage Vargoth",
 	text: "At the end of your turn, cast a spell you've cast this turn <i>(targets are random)</i>.",
 	cost: 4,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: true,
 	tags: [],
 	id: 98,
 
 	attack: 2,
 	health: 6,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async passive(owner, self, key, _unknownValue) {
 		// At the end of your turn, cast a spell you've cast this turn (targets are random).
@@ -31,7 +38,7 @@ export const blueprint: Blueprint = {
 			.filter(
 				(object) =>
 					object[0] instanceof Card &&
-					object[0].type === "Spell" &&
+					object[0].type === Type.Spell &&
 					object[1] === game.turn,
 			)
 			.map((object) => object[0] as Card);
@@ -43,7 +50,7 @@ export const blueprint: Blueprint = {
 		const spell = game.lodash.sample(spells);
 
 		owner.forceTarget = game.functions.util.getRandomTarget();
-		await spell?.activate("cast");
+		await spell?.activate(Ability.Cast);
 		owner.forceTarget = undefined;
 	},
 

--- a/cards/Classes/Neutral/Collectible/Minions/9-Cost/106-yogg-saron-unleashed.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/9-Cost/106-yogg-saron-unleashed.ts
@@ -2,26 +2,35 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	type EventValue,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Yogg-Saron, Unleashed",
 	text: "<b>Titan</b> After this uses an ability, cast two random spells.",
 	cost: 9,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: true,
 	tags: [],
 	id: 106,
 
 	attack: 7,
 	health: 5,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Add additional fields here
-		self.addKeyword("Titan", [
+		self.addKeyword(Keyword.Titan, [
 			game.cardIds.induceInsanity107,
 			game.cardIds.reignOfChaos108,
 			game.cardIds.tentacleSwarm109,
@@ -46,7 +55,7 @@ export const blueprint: Blueprint = {
 			return;
 		}
 
-		const pool = (await Card.all()).filter((card) => card.type === "Spell");
+		const pool = (await Card.all()).filter((card) => card.type === Type.Spell);
 
 		for (let i = 0; i < 2; i++) {
 			const card = await game.lodash.sample(pool)?.imperfectCopy();
@@ -54,7 +63,7 @@ export const blueprint: Blueprint = {
 				continue;
 			}
 
-			await card.activate("cast");
+			await card.activate(Ability.Cast);
 		}
 	},
 

--- a/cards/Classes/Neutral/Uncollectible/Minions/1-Cost/99-onyxian-whelp.ts
+++ b/cards/Classes/Neutral/Uncollectible/Minions/1-Cost/99-onyxian-whelp.ts
@@ -1,24 +1,31 @@
 // Created by the Vanilla Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Onyxian Whelp",
 	text: "<b>Rush</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 99,
 
 	attack: 2,
 	health: 1,
-	tribe: "Dragon",
+	tribe: MinionTribe.Dragon,
 
 	async create(owner, self) {
 		// Add additional fields here
-		self.addKeyword("Rush");
+		self.addKeyword(Keyword.Rush);
 	},
 };

--- a/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/107-induce-insanity.ts
+++ b/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/107-induce-insanity.ts
@@ -3,20 +3,26 @@
 // This is the Yogg-Saron, Unleashed Induce Insanity card.
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Induce Insanity",
 	text: "Force each enemy minion to attack a random enemy minion.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 107,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Force each enemy minion to attack a random enemy minion.

--- a/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/108-reign-of-chaos.ts
+++ b/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/108-reign-of-chaos.ts
@@ -4,27 +4,35 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	TargetAlignment,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Reign of Chaos",
 	text: "Take control of an enemy minion.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 108,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Take control of an enemy minion.
 		const card = await game.functions.interact.prompt.targetCard(
 			self.text,
 			self,
-			"enemy",
+			TargetAlignment.Enemy,
 		);
 		if (!card) {
 			return Card.REFUND;
@@ -49,7 +57,7 @@ export const blueprint: Blueprint = {
 
 		// Activate cast and make the player choose the sheep
 		owner.inputQueue = ["1"];
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// Check if the sheep's owner is the friendly player, is on this side of the board, and not the opponent's side of the board
 		assert.equal(sheep.owner, owner);

--- a/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/109-tentacle-swarm.ts
+++ b/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/109-tentacle-swarm.ts
@@ -4,20 +4,27 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Tentacle Swarm",
 	text: "Fill your hand with 1/1 Chaotic Tendrils.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 109,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Fill your hand with 1/1 Chaotic Tendrils.
@@ -31,7 +38,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		const handSize = owner.hand.length;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// Check if the player's hand was filled with tendrils
 		const amountOfCards = owner.hand.length - handSize;

--- a/cards/Debug/65-10-mana.ts
+++ b/cards/Debug/65-10-mana.ts
@@ -1,20 +1,27 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "10 Mana",
 	text: "Gain 10 Mana.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 65,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Gain 10 Mana.
@@ -23,7 +30,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		owner.mana = 5;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.mana, 10);
 	},

--- a/cards/Debug/66-inf-mana.ts
+++ b/cards/Debug/66-inf-mana.ts
@@ -2,20 +2,28 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Event,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Inf Mana",
 	text: "Fill up your mana. For the rest of the game, your mana never decreases.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 66,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Fill up your mana. For the rest of the game, your mana never decreases.
@@ -31,13 +39,13 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		owner.mana = 5;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// The game hasn't ticked yet
 		assert.equal(owner.mana, 5);
 
 		// Manually tick the game
-		await game.event.tick("GameLoop", undefined, owner);
+		await game.event.tick(Event.GameLoop, undefined, owner);
 
 		assert.equal(owner.mana, 10);
 

--- a/cards/Debug/66-inf-mana.ts
+++ b/cards/Debug/66-inf-mana.ts
@@ -7,6 +7,7 @@ import {
 	type Blueprint,
 	Class,
 	Event,
+	GamePlayCardReturn,
 	Rarity,
 	SpellSchool,
 	Type,
@@ -53,7 +54,7 @@ export const blueprint: Blueprint = {
 		const card = await Card.create(game.cardIds.sheep1, owner);
 		const result = await game.play(card, owner);
 
-		assert.equal(result, true);
+		assert.equal(result, GamePlayCardReturn.Success);
 		assert.equal(owner.mana, 10);
 	},
 };

--- a/cards/Examples/1/1-minion.ts
+++ b/cards/Examples/1/1-minion.ts
@@ -1,7 +1,13 @@
 // Created by Hand
 
 // You shouldn't touch anything outside of the blueprint object.
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	/*
@@ -21,13 +27,13 @@ export const blueprint: Blueprint = {
 	cost: 1,
 
 	// The type of the card. E.g. "Minion", "Spell", "Weapon", etc...
-	type: "Minion",
+	type: Type.Minion,
 
 	// The classes of the card. E.g. "Neutral", "Warrior", "Hunter", etc...
-	classes: ["Neutral"],
+	classes: [Class.Neutral],
 
 	// The rarity of the card. E.g. "Free", "Common", "Rare", etc...
-	rarity: "Free",
+	rarity: Rarity.Free,
 
 	/*
 	 * If the card should be allowed in decks or card pools.
@@ -59,5 +65,5 @@ export const blueprint: Blueprint = {
 	health: 1,
 
 	// The tribe of the minion. E.g. "Undead", "Naga", "Beast", etc...
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/Examples/1/2-spell.ts
+++ b/cards/Examples/1/2-spell.ts
@@ -1,19 +1,25 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	// If a field doesn't get a comment to itself, it has already been explained in a previous example card.
 	name: "Spell Example",
 	text: "Just an example card (Does nothing)",
 	cost: 1,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 30,
 
 	// The school of the spell.
-	spellSchool: "Shadow",
+	spellSchool: SpellSchool.Shadow,
 };

--- a/cards/Examples/1/3-weapon.ts
+++ b/cards/Examples/1/3-weapon.ts
@@ -1,6 +1,6 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	// This looks like a minion card except for the type and no tribe.
@@ -9,10 +9,10 @@ export const blueprint: Blueprint = {
 	cost: 1,
 
 	// Remember to properly set the type (Done automatically by the card creator)
-	type: "Weapon",
+	type: Type.Weapon,
 
-	classes: ["Neutral"],
-	rarity: "Free",
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 31,

--- a/cards/Examples/1/4-taunt.ts
+++ b/cards/Examples/1/4-taunt.ts
@@ -1,6 +1,13 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Taunt Example",
@@ -14,10 +21,10 @@ export const blueprint: Blueprint = {
 	text: "<b>Taunt.</b> This is an example card to show how to add keywords to cards.",
 
 	cost: 1,
-	type: "Minion",
-	tribe: "None",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	tribe: MinionTribe.None,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 32,
@@ -31,6 +38,6 @@ export const blueprint: Blueprint = {
 	 */
 	async create(owner, self) {
 		// Add the Taunt keyword to this card
-		self.addKeyword("Taunt");
+		self.addKeyword(Keyword.Taunt);
 	},
 };

--- a/cards/Examples/1/5-battlecry.ts
+++ b/cards/Examples/1/5-battlecry.ts
@@ -1,7 +1,14 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Battlecry Example",
@@ -13,16 +20,16 @@ export const blueprint: Blueprint = {
 	text: "<b>Battlecry:</b> Give this minion +1/+1.",
 
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 33,
 
 	attack: 1,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	/*
 	 * Here we put the name of the ability we want to add.
@@ -51,7 +58,7 @@ export const blueprint: Blueprint = {
 	 * These tests are run in an isolated environment. The side-effect of the code here won't carry over to other tests or the game.
 	 */
 	async test(owner, self) {
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		assert.equal((self.blueprint.attack ?? 0) + 1, self.attack);
 		assert.equal((self.blueprint.health ?? 0) + 1, self.health);

--- a/cards/Examples/1/6-dredge.ts
+++ b/cards/Examples/1/6-dredge.ts
@@ -1,22 +1,28 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Dredge Example",
 	text: "This example card shows you how to use keywords like dredge. <b>Battlecry: Dredge.</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 34,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Dredge.

--- a/cards/Examples/1/7-another-ability.ts
+++ b/cards/Examples/1/7-another-ability.ts
@@ -1,19 +1,27 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Ability, Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type AbilityCallback,
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 /*
  * This is another way to write blueprints
  * You might want to do this if you make a very complicated card
  * however it is not _as_ supported by scripts as the default method.
  */
-const battlecry: Ability = async (owner, self) => {
+const battlecry: AbilityCallback = async (owner, self) => {
 	await self.addStats(1, 1);
 };
 
-const theTestAbility: Ability = async (owner, self) => {
-	await self.activate("battlecry");
+const theTestAbility: AbilityCallback = async (owner, self) => {
+	await self.activate(Ability.Battlecry);
 
 	assert.equal((self.blueprint.attack ?? 0) + 1, self.attack);
 	assert.equal((self.blueprint.health ?? 0) + 1, self.health);
@@ -23,16 +31,16 @@ export const blueprint: Blueprint = {
 	name: "Another Ability Example",
 	text: "<b>Battlecry:</b> Give this minion +1/+1.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 77,
 
 	attack: 1,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	// If the function is named correctly, you can just write the name of the ability
 	battlecry,

--- a/cards/Examples/1/last-combined.ts
+++ b/cards/Examples/1/last-combined.ts
@@ -1,7 +1,15 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Combined Example 1",
@@ -10,9 +18,9 @@ export const blueprint: Blueprint = {
 	text: "<b>Taunt, Divine Shield. Battlecry: Dredge.</b> Gain +1/+1. (This example card combines everything you've learned in stage 1 into this card.)",
 
 	cost: 1,
-	type: "Minion",
-	classes: ["Priest", "Paladin"],
-	rarity: "Legendary",
+	type: Type.Minion,
+	classes: [Class.Priest, Class.Paladin],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 35,
@@ -21,13 +29,13 @@ export const blueprint: Blueprint = {
 	health: 4,
 
 	// You can set the tribe to "All" for "This has all minion types"
-	tribe: "All",
+	tribe: MinionTribe.All,
 
 	async create(owner, self) {
 		// Taunt, Divine Shield
 
-		self.addKeyword("Taunt");
-		self.addKeyword("Divine Shield");
+		self.addKeyword(Keyword.Taunt);
+		self.addKeyword(Keyword.DivineShield);
 	},
 
 	async battlecry(owner, self) {
@@ -45,7 +53,7 @@ export const blueprint: Blueprint = {
 		owner.inputQueue = ["1"];
 
 		// We can't really check the dredged card here.
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		// Check that the stats went up by 1
 		assert.equal((self.blueprint.attack ?? 0) + 1, self.attack);

--- a/cards/Examples/2/1-location.ts
+++ b/cards/Examples/2/1-location.ts
@@ -1,7 +1,7 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 // This is the first card in this stage. The next card in this stage is the `2-Hero` folder.
 
@@ -9,9 +9,9 @@ export const blueprint: Blueprint = {
 	name: "Location Example",
 	text: "Restore 2 Health to your hero.",
 	cost: 1,
-	type: "Location",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Location,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 36,
@@ -38,7 +38,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		owner.health = 1;
-		await self.activate("use");
+		await self.activate(Ability.Use);
 
 		assert.equal(owner.health, 1 + 2);
 	},

--- a/cards/Examples/2/2-Hero/2-hero.ts
+++ b/cards/Examples/2/2-Hero/2-hero.ts
@@ -1,7 +1,7 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 // This is the second card in this stage. The first card in this stage is the `1-location.ts` file.
 
@@ -9,9 +9,9 @@ export const blueprint: Blueprint = {
 	name: "Hero Example",
 	text: "<b>Battlecry:</b> Restore your hero to full health.",
 	cost: 1,
-	type: "Hero",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 37,
@@ -36,7 +36,7 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// Test battlecry
 		owner.health = 1;
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 		assert.equal(owner.health, owner.maxHealth);
 	},
 };

--- a/cards/Examples/2/2-Hero/2-heropower.ts
+++ b/cards/Examples/2/2-Hero/2-heropower.ts
@@ -1,7 +1,7 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Heropower Example",
@@ -9,10 +9,10 @@ export const blueprint: Blueprint = {
 	cost: 2,
 
 	// Remember to set the type to "Heropower"
-	type: "Heropower",
+	type: Type.HeroPower,
 
-	classes: ["Neutral"],
-	rarity: "Free",
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 130,
@@ -27,7 +27,7 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// Test hero power
 		owner.health = 1;
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 		assert.equal(owner.health, 1 + 2);
 	},
 };

--- a/cards/Examples/2/3-dormant.ts
+++ b/cards/Examples/2/3-dormant.ts
@@ -1,21 +1,28 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Dormant Example",
 	text: "<b>Dormant</b> for 2 turns. <b>Battlecry:</b> Dredge.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 38,
 
 	attack: 8,
 	health: 8,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		/*
@@ -23,7 +30,7 @@ export const blueprint: Blueprint = {
 		 * Full disclosure: The dormant system is one of the most untested parts of this game.
 		 * If you find any bugs, please open an issue.
 		 */
-		self.addKeyword("Dormant", 2);
+		self.addKeyword(Keyword.Dormant, 2);
 	},
 
 	// The battlecry only triggers when the minion is no longer dormant.

--- a/cards/Examples/2/4-runes.ts
+++ b/cards/Examples/2/4-runes.ts
@@ -1,21 +1,27 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Rune Example",
 	text: "This is an example card to show how runes work.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 39,
 
 	attack: 1,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// You need 2 frost runes and 1 blood rune to use this card.

--- a/cards/Examples/2/5-corrupt.ts
+++ b/cards/Examples/2/5-corrupt.ts
@@ -1,28 +1,35 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Corrupt Example",
 	text: "<b>Corrupt.</b>",
 	cost: 0,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 40,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		/*
 		 * Put the id of the corrupted counterpart here. This is the id of 5-corrupted.ts
 		 * Corrupted is another system that is very untested and might get a rewrite.
 		 */
-		self.addKeyword("Corrupt", game.cardIds.corruptedExample41);
+		self.addKeyword(Keyword.Corrupt, game.cardIds.corruptedExample41);
 	},
 
 	async test(owner, self) {

--- a/cards/Examples/2/5-corrupted.ts
+++ b/cards/Examples/2/5-corrupted.ts
@@ -1,6 +1,12 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	/*
@@ -10,14 +16,14 @@ export const blueprint: Blueprint = {
 	name: "Corrupted Example",
 	text: "Corrupted.",
 	cost: 0,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 41,
 
 	attack: 2,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/Examples/2/6-forge.ts
+++ b/cards/Examples/2/6-forge.ts
@@ -1,24 +1,31 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Forge Example",
 	text: "<b>Forge:</b> Gain +1/+1.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 75,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Put the id of the forged counterpart, like in corrupt.
-		self.addKeyword("Forge", game.cardIds.forgedExample76);
+		self.addKeyword(Keyword.Forge, game.cardIds.forgedExample76);
 	},
 };

--- a/cards/Examples/2/6-forged.ts
+++ b/cards/Examples/2/6-forged.ts
@@ -1,6 +1,12 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	/*
@@ -10,14 +16,14 @@ export const blueprint: Blueprint = {
 	name: "Forged Example",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 76,
 
 	attack: 2,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/Examples/2/7-Titan/7-ability1.ts
+++ b/cards/Examples/2/7-Titan/7-ability1.ts
@@ -2,21 +2,28 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	// Look in `titan.ts` first.
 	name: "Ability 1",
 	text: "Destroy a random enemy minion.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 79,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Destroy a random enemy minion.
@@ -49,7 +56,7 @@ export const blueprint: Blueprint = {
 		await opponent.summon(sheep);
 
 		// Kill the sheep
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		// Check if the sheep is dead
 		assert.equal(owner.board.length, 0);

--- a/cards/Examples/2/7-Titan/7-ability2.ts
+++ b/cards/Examples/2/7-Titan/7-ability2.ts
@@ -1,21 +1,28 @@
 // Created by Hand (before the Card Creator Existed)
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	// Look in `titan.ts` first.
 	name: "Ability 2",
 	text: "Heal 3 damage.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 80,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Heal 3 damage.
@@ -25,7 +32,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		owner.health = owner.maxHealth - 5;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.health, owner.maxHealth - 2);
 	},

--- a/cards/Examples/2/7-Titan/7-ability3.ts
+++ b/cards/Examples/2/7-Titan/7-ability3.ts
@@ -1,21 +1,28 @@
 // Created by Hand (before the Card Creator Existed)
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	// Look in `titan.ts` first.
 	name: "Ability 3",
 	text: "Restore 2 mana.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 81,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Restore 2 mana.
@@ -28,7 +35,7 @@ export const blueprint: Blueprint = {
 		owner.emptyMana = 10;
 
 		const { mana } = owner;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.mana, mana + 2);
 	},

--- a/cards/Examples/2/7-Titan/7-titan.ts
+++ b/cards/Examples/2/7-Titan/7-titan.ts
@@ -1,25 +1,32 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Titan Example",
 	text: "<b>Titan</b>.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 78,
 
 	attack: 10,
 	health: 10,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Put the ids of the titan ability cards, like in corrupt, but a list.
-		self.addKeyword("Titan", [
+		self.addKeyword(Keyword.Titan, [
 			game.cardIds.ability179,
 			game.cardIds.ability280,
 			game.cardIds.ability381,

--- a/cards/Examples/2/8-spelldamage.ts
+++ b/cards/Examples/2/8-spelldamage.ts
@@ -1,7 +1,14 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Spell Damage Example",
@@ -15,14 +22,14 @@ export const blueprint: Blueprint = {
 	text: "Deal $3 damage to the enemy hero.",
 
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 42,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Deal $3 damage to the enemy hero.
@@ -38,7 +45,7 @@ export const blueprint: Blueprint = {
 		const oldHealth = owner.getOpponent().health;
 
 		owner.spellDamage = 3;
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(
 			owner.getOpponent().health,

--- a/cards/Examples/2/9-Colossal/left.ts
+++ b/cards/Examples/2/9-Colossal/left.ts
@@ -1,6 +1,12 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	/*
@@ -10,14 +16,14 @@ export const blueprint: Blueprint = {
 	name: "Left Arm",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 43,
 
 	attack: 2,
 	health: 1,
-	tribe: "Beast",
+	tribe: MinionTribe.Beast,
 };

--- a/cards/Examples/2/9-Colossal/main.ts
+++ b/cards/Examples/2/9-Colossal/main.ts
@@ -1,22 +1,29 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Colossal Example",
 	text: "Colossal +2.",
 	cost: 2,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 45,
 
 	attack: 5,
 	health: 3,
-	tribe: "Beast",
+	tribe: MinionTribe.Beast,
 
 	async create(owner, self) {
 		/*
@@ -27,7 +34,7 @@ export const blueprint: Blueprint = {
 		 * Colossal Example
 		 * Right Arm
 		 */
-		self.addKeyword("Colossal", [
+		self.addKeyword(Keyword.Colossal, [
 			game.cardIds.leftArm43,
 			game.cardIds.null0,
 			game.cardIds.rightArm44,

--- a/cards/Examples/2/9-Colossal/right.ts
+++ b/cards/Examples/2/9-Colossal/right.ts
@@ -1,6 +1,12 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	/*
@@ -10,14 +16,14 @@ export const blueprint: Blueprint = {
 	name: "Right Arm",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 44,
 
 	attack: 1,
 	health: 2,
-	tribe: "Beast",
+	tribe: MinionTribe.Beast,
 };

--- a/cards/Examples/2/last-Combined/left.ts
+++ b/cards/Examples/2/last-Combined/left.ts
@@ -1,19 +1,25 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Left Arm",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 46,
 
 	attack: 3,
 	health: 3,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/Examples/2/last-Combined/main-corrupted.ts
+++ b/cards/Examples/2/last-Combined/main-corrupted.ts
@@ -1,30 +1,37 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Combined Example 2 Corrupted",
 	text: "Colossal +2. Dormant. Corrupted. <b>Battlecry: Dredge.</b>",
 	cost: 0,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 49,
 
 	attack: 9,
 	health: 9,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
-		self.addKeyword("Colossal", [
+		self.addKeyword(Keyword.Colossal, [
 			game.cardIds.leftArm46,
 			game.cardIds.null0,
 			game.cardIds.rightArm47,
 		]);
 
-		self.addKeyword("Dormant", 2);
+		self.addKeyword(Keyword.Dormant, 2);
 	},
 
 	async battlecry(owner, self) {

--- a/cards/Examples/2/last-Combined/main.ts
+++ b/cards/Examples/2/last-Combined/main.ts
@@ -1,34 +1,41 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Combined Example 2",
 	text: "Colossal +2. Dormant. Corrupt.",
 	cost: 0,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 48,
 
 	attack: 5,
 	health: 3,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		self.runes = "BBB";
 
-		self.addKeyword("Colossal", [
+		self.addKeyword(Keyword.Colossal, [
 			game.cardIds.leftArm46,
 			game.cardIds.null0,
 			game.cardIds.rightArm47,
 		]);
 
-		self.addKeyword("Corrupt", game.cardIds.combinedExample2Corrupted49);
+		self.addKeyword(Keyword.Corrupt, game.cardIds.combinedExample2Corrupted49);
 
 		// The summoned minions get Dormant automatically if the main minion has dormant.
-		self.addKeyword("Dormant", 2);
+		self.addKeyword(Keyword.Dormant, 2);
 	},
 };

--- a/cards/Examples/2/last-Combined/right.ts
+++ b/cards/Examples/2/last-Combined/right.ts
@@ -1,19 +1,25 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Right Arm",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 47,
 
 	attack: 1,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/Examples/3/1-manathirst.ts
+++ b/cards/Examples/3/1-manathirst.ts
@@ -2,22 +2,31 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	TargetAlignment,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Manathirst Example",
 	text: "<b>Battlecry:</b> Freeze an enemy minion. Manathirst (6): Silence it first.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 50,
 
 	attack: 1,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		const manathirst = self.manathirst(6);
@@ -38,7 +47,7 @@ export const blueprint: Blueprint = {
 		const target = await game.functions.interact.prompt.targetCard(
 			prompt,
 			self,
-			"enemy",
+			TargetAlignment.Enemy,
 		);
 
 		// If target is null, it means that the user cancelled their selection. Return `Card.REFUND` to refund the card.
@@ -70,22 +79,22 @@ export const blueprint: Blueprint = {
 
 		assert.equal(sheep.attack, 5);
 		assert.equal(sheep.health, 5);
-		assert(!sheep.hasKeyword("Frozen"));
+		assert(!sheep.hasKeyword(Keyword.Frozen));
 
 		owner.emptyMana = 1;
 		assert.equal(owner.emptyMana, 1);
 		owner.inputQueue = ["1"];
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
-		assert(sheep.hasKeyword("Frozen"));
-		sheep.remKeyword("Frozen");
-		assert(!sheep.hasKeyword("Frozen"));
+		assert(sheep.hasKeyword(Keyword.Frozen));
+		sheep.remKeyword(Keyword.Frozen);
+		assert(!sheep.hasKeyword(Keyword.Frozen));
 
 		owner.emptyMana = 6;
 		owner.inputQueue = ["1"];
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
-		assert(sheep.hasKeyword("Frozen"));
+		assert(sheep.hasKeyword(Keyword.Frozen));
 		assert.equal(sheep.attack, 1);
 		assert.equal(sheep.health, 1);
 	},

--- a/cards/Examples/3/2-discover.ts
+++ b/cards/Examples/3/2-discover.ts
@@ -2,20 +2,27 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Discover Example",
 	text: "Discover a spell.",
 	cost: 1,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 51,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Discover a spell.
@@ -29,7 +36,7 @@ export const blueprint: Blueprint = {
 		let pool = await Card.all();
 
 		// We need to filter away any non-spell cards.
-		pool = pool.filter((c) => c.type === "Spell");
+		pool = pool.filter((c) => c.type === Type.Spell);
 
 		// game.functions.interact.discover(prompt, pool, ifItShouldFilterAwayCardsThatAreNotThePlayersClass = true, amountOfCardsToChooseFrom = 3)
 		const spell = await game.functions.interact.prompt.discover(
@@ -52,7 +59,7 @@ export const blueprint: Blueprint = {
 		owner.hand = [];
 
 		for (let i = 0; i < 50; i++) {
-			await self.activate("cast");
+			await self.activate(Ability.Cast);
 
 			const card = owner.hand.pop();
 

--- a/cards/Examples/3/3-condition.ts
+++ b/cards/Examples/3/3-condition.ts
@@ -2,7 +2,14 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Condition Example",
@@ -11,16 +18,16 @@ export const blueprint: Blueprint = {
 	text: "<b>Battlecry:</b> If your deck has no duplicates, draw a card.",
 
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 52,
 
 	attack: 5,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// If your deck has no duplicates, draw a card.
@@ -54,7 +61,7 @@ export const blueprint: Blueprint = {
 
 		// The player shouldn't fulfill the condition
 		assert(!owner.highlander());
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		// Assert that the player didn't draw a card
 		assert.equal(owner.deck.length, length);
@@ -65,7 +72,7 @@ export const blueprint: Blueprint = {
 		assert(owner.highlander());
 		assert.equal(owner.deck.length, 1);
 
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		assert.equal(owner.hand.length, 1);
 	},

--- a/cards/Examples/3/4-placeholder.ts
+++ b/cards/Examples/3/4-placeholder.ts
@@ -1,7 +1,13 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Placeholder Example",
@@ -10,14 +16,14 @@ export const blueprint: Blueprint = {
 	text: "Battlecry: Gain mana equal to the turn counter. (Currently {turns}, {laugh}, {turns}, {next thing is} {test}, {placeholder without replacement})",
 
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 53,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Gain mana equal to the turn counter.

--- a/cards/Examples/3/last-combined.ts
+++ b/cards/Examples/3/last-combined.ts
@@ -1,20 +1,27 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Combined Example 3",
 	text: "If the turn counter is an even number, gain mana equal to the turn counter (up to 10). Manathirst (7): Remove the condition. (Currently: {turns})",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 54,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		if (!(await self.condition())) {
@@ -68,7 +75,7 @@ export const blueprint: Blueprint = {
 		// The condition is not cleared
 		let { mana } = owner;
 		assert.equal(turn(), 1);
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.mana, mana);
 
@@ -79,7 +86,7 @@ export const blueprint: Blueprint = {
 		// The condition is cleared, gain 2 mana.
 		mana = owner.mana;
 		assert.equal(turn(), 2);
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.mana, mana + 2);
 
@@ -91,7 +98,7 @@ export const blueprint: Blueprint = {
 		owner.emptyMana = 7;
 		mana = owner.mana;
 		assert.equal(turn(), 3);
-		await self.activate("cast");
+		await self.activate(Ability.Cast);
 
 		assert.equal(owner.mana, mana + 3);
 	},

--- a/cards/Examples/4/1-passive.ts
+++ b/cards/Examples/4/1-passive.ts
@@ -1,6 +1,14 @@
 // Created by Hand
 
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	type EventValue,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 // Im sorry, things are about to become a lot more complicated from this point on.
 export const blueprint: Blueprint = {
@@ -10,16 +18,16 @@ export const blueprint: Blueprint = {
 	text: "Your battlecries trigger twice.",
 
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 55,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	/*
 	 * Note the new `key`, `_unknownValue` and `eventPlayer` arguments.
@@ -66,7 +74,7 @@ export const blueprint: Blueprint = {
 		 */
 
 		// We check if the card played is not a minion (this is not neccessary in this case since if the card doesn't have a battlecry, it won't do anything, but it is here for clarity)
-		if (value.type !== "Minion") {
+		if (value.type !== Type.Minion) {
 			return;
 		}
 
@@ -77,7 +85,7 @@ export const blueprint: Blueprint = {
 		 * Remember, this passive triggers after the minion's battlecry (in order to handle refunding).
 		 * This means that once we trigger the battlecry here, the minion's battlecry will have triggered twice in total.
 		 */
-		await value.activate("battlecry");
+		await value.activate(Ability.Battlecry);
 	},
 
 	async test(owner, self) {

--- a/cards/Examples/4/2-enchantments.ts
+++ b/cards/Examples/4/2-enchantments.ts
@@ -1,21 +1,27 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Enchantment Example",
 	text: "Your cards cost 1 less.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 56,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	/*
 	 * `tick` works the same as passive, except it's called more often, and isn't dependent on events.

--- a/cards/Examples/4/3-event-listener.ts
+++ b/cards/Examples/4/3-event-listener.ts
@@ -1,21 +1,31 @@
 // Created by Hand
 
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Event,
+	EventListenerMessage,
+	type EventValue,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Event Listener Example",
 	text: "Battlecry: For the rest of the game, your battlecries trigger twice.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 57,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// For the rest of the game, your battlecries trigger twice.
@@ -32,12 +42,12 @@ export const blueprint: Blueprint = {
 		 * The third argument is the event listeners' lifespan.
 		 */
 		const destroy = game.event.addListener(
-			"PlayCard",
+			Event.PlayCard,
 			async (_unknownValue, eventPlayer) => {
 				// This function will be run when the correct event is broadcast.
 
 				// addListener can't figure out the type of `val` by itself, so we have to do the same thing as with passives.
-				const value = _unknownValue as EventValue<"PlayCard">;
+				const value = _unknownValue as EventValue<Event.PlayCard>;
 
 				/*
 				 * Only continue if the player that triggered the event is this card's owner and the played card is a minion and it is not this card.
@@ -45,24 +55,24 @@ export const blueprint: Blueprint = {
 				 * The return value will be explained below.
 				 */
 				if (
-					value.type !== "Minion" ||
+					value.type !== Type.Minion ||
 					eventPlayer !== owner ||
 					value === self
 				) {
-					return false;
+					return EventListenerMessage.Ignore;
 				}
 
 				// Activate the battlecry
-				await value.activate("battlecry");
+				await value.activate(Ability.Battlecry);
 
 				/*
 				 * You have to return a message to the event listener handler to tell it what to do next.
-				 * If you return "destroy", the event listener gets destroyed (this is the same as running the `destroy` function).
-				 * If you return "reset", the event listener's lifetime is reset to 1, resetting the event listeners age. This is rarely useful, but is an option.
-				 * If you return false, this event does not count towards the event listeners lifetime.
-				 * If you return true, nothing happens. The event will count towards the event listeners lifetime. This is the most useful / default option.
+				 * If you return `Destroy`, the event listener gets destroyed (this is the same as running the `destroy` function).
+				 * If you return `Reset`, the event listener's lifetime is reset to 1, resetting the event listeners age. This is rarely useful, but is an option.
+				 * If you return `Ignore`, this event does not count towards the event listeners lifetime.
+				 * If you return `Success`, nothing happens. The event will count towards the event listeners lifetime. This is the most useful / default option.
 				 */
-				return true;
+				return EventListenerMessage.Success;
 			},
 			-1, // This number is how many times the callback function can run before the event listener self-destructs. If this is set to `-1`, it lasts forever.
 		);

--- a/cards/Examples/4/3-event-listener.ts
+++ b/cards/Examples/4/3-event-listener.ts
@@ -59,7 +59,7 @@ export const blueprint: Blueprint = {
 					eventPlayer !== owner ||
 					value === self
 				) {
-					return EventListenerMessage.Ignore;
+					return EventListenerMessage.Skip;
 				}
 
 				// Activate the battlecry
@@ -69,7 +69,7 @@ export const blueprint: Blueprint = {
 				 * You have to return a message to the event listener handler to tell it what to do next.
 				 * If you return `Destroy`, the event listener gets destroyed (this is the same as running the `destroy` function).
 				 * If you return `Reset`, the event listener's lifetime is reset to 1, resetting the event listeners age. This is rarely useful, but is an option.
-				 * If you return `Ignore`, this event does not count towards the event listeners lifetime.
+				 * If you return `Skip`, this event does not count towards the event listeners lifetime.
 				 * If you return `Success`, nothing happens. The event will count towards the event listeners lifetime. This is the most useful / default option.
 				 */
 				return EventListenerMessage.Success;

--- a/cards/Examples/4/4-quest.ts
+++ b/cards/Examples/4/4-quest.ts
@@ -1,7 +1,15 @@
 // Created by Hand
 
 import type { Card } from "@Core/card.js";
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Event,
+	type EventValue,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Quest Example",
@@ -10,14 +18,14 @@ export const blueprint: Blueprint = {
 	text: "Quest: Play 3 cards. Reward: Return those cards back to your hand.",
 
 	cost: 1,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 58,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Quest: Play 3 cards. Reward: Return those cards back to your hand.
@@ -40,7 +48,7 @@ export const blueprint: Blueprint = {
 		await owner.addQuest(
 			"Quest",
 			self,
-			"PlayCard",
+			Event.PlayCard,
 			3,
 			async (_unknownValue, done) => {
 				/*
@@ -49,7 +57,7 @@ export const blueprint: Blueprint = {
 				 */
 
 				// Get the value of the event
-				const value = _unknownValue as EventValue<"PlayCard">;
+				const value = _unknownValue as EventValue<Event.PlayCard>;
 
 				/*
 				 * Returning false will prevent this event from counting towards the quest

--- a/cards/Examples/4/4-quest.ts
+++ b/cards/Examples/4/4-quest.ts
@@ -5,7 +5,9 @@ import {
 	type Blueprint,
 	Class,
 	Event,
+	EventListenerMessage,
 	type EventValue,
+	QuestType,
 	Rarity,
 	SpellSchool,
 	Type,
@@ -42,11 +44,11 @@ export const blueprint: Blueprint = {
 		 *     the function to run for each event broadcast: Function(
 		 *         value of the event,
 		 *         if the quest is considered done,
-		 *     ) -> if the event should count towards the quest: bool
+		 *     ) -> a message to deliver to the event manager
 		 * );
 		 */
 		await owner.addQuest(
-			"Quest",
+			QuestType.Quest,
 			self,
 			Event.PlayCard,
 			3,
@@ -70,7 +72,7 @@ export const blueprint: Blueprint = {
 				 * which triggers this quest. So we need to prevent that event from counting towards the quest.
 				 */
 				if (value === self) {
-					return false;
+					return EventListenerMessage.Skip;
 				}
 
 				// Otherwise, add it to the cards array, and count it.
@@ -81,7 +83,7 @@ export const blueprint: Blueprint = {
 				 * Only return if the quest isn't considered done. It is considered done if the quest has been triggered enough times (in this case 3).
 				 */
 				if (!done) {
-					return true;
+					return EventListenerMessage.Success;
 				}
 
 				// The quest is done. The code above has been triggered 3 times in total.
@@ -104,10 +106,10 @@ export const blueprint: Blueprint = {
 				}
 
 				/*
-				 * Return true to count this event towards the quest
+				 * Return `Success` to count this event towards the quest
 				 * This finishes the quest
 				 */
-				return true;
+				return EventListenerMessage.Success;
 			},
 			// Put the id of a spell here to make a questline. When the quest gets completed, a card with that id gets created and the game immediately activates its cast ability.
 		);

--- a/cards/Examples/4/5-tick-hooks.ts
+++ b/cards/Examples/4/5-tick-hooks.ts
@@ -1,21 +1,27 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Tick Hook Example",
 	text: "Your cards cost (1) less.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 59,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Initialize storage

--- a/cards/Examples/4/last-combined.ts
+++ b/cards/Examples/4/last-combined.ts
@@ -6,6 +6,7 @@ import {
 	Event,
 	EventListenerMessage,
 	type EventValue,
+	QuestType,
 	Rarity,
 	SpellSchool,
 	Type,
@@ -27,7 +28,7 @@ export const blueprint: Blueprint = {
 
 	async cast(owner, self) {
 		await owner.addQuest(
-			"Quest",
+			QuestType.Quest,
 			self,
 			Event.PlayCard,
 			3,
@@ -35,11 +36,11 @@ export const blueprint: Blueprint = {
 				const value = _unknownValue as EventValue<Event.PlayCard>;
 
 				if (value === self) {
-					return false;
+					return EventListenerMessage.Skip;
 				}
 
 				if (!done) {
-					return true;
+					return EventListenerMessage.Success;
 				}
 
 				/*
@@ -69,7 +70,7 @@ export const blueprint: Blueprint = {
 
 						// Only continue if the player that triggered the event is this card's owner and the played card is a minion.
 						if (eventPlayer !== owner || value.type !== Type.Minion) {
-							return EventListenerMessage.Ignore;
+							return EventListenerMessage.Skip;
 						}
 
 						// Every time YOU play a MINION, increment `amount` by 1.
@@ -100,7 +101,7 @@ export const blueprint: Blueprint = {
 				);
 
 				// The quest event was a success. The game will remove this quest from the player.
-				return true;
+				return EventListenerMessage.Success;
 			},
 		);
 	},

--- a/cards/Examples/4/last-combined.ts
+++ b/cards/Examples/4/last-combined.ts
@@ -1,29 +1,38 @@
 // Created by Hand
 
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Event,
+	EventListenerMessage,
+	type EventValue,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 // This is the big one
 export const blueprint: Blueprint = {
 	name: "Combined Example 4",
 	text: "Quest: Play 3 cards. Reward: Reduce the cost of the next 10 Minions you play by 1.",
 	cost: 1,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Legendary",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 60,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		await owner.addQuest(
 			"Quest",
 			self,
-			"PlayCard",
+			Event.PlayCard,
 			3,
 			async (_unknownValue, done) => {
-				const value = _unknownValue as EventValue<"PlayCard">;
+				const value = _unknownValue as EventValue<Event.PlayCard>;
 
 				if (value === self) {
 					return false;
@@ -40,7 +49,7 @@ export const blueprint: Blueprint = {
 				const unhook = game.event.hookToTick(async () => {
 					// Only add the enchantment to minions
 					for (const minion of owner.hand.filter(
-						(card) => card.type === "Minion",
+						(card) => card.type === Type.Minion,
 					)) {
 						if (minion.enchantmentExists("-1 cost", self)) {
 							continue;
@@ -54,13 +63,13 @@ export const blueprint: Blueprint = {
 				let amount = 0;
 
 				game.event.addListener(
-					"PlayCard",
+					Event.PlayCard,
 					async (_unknownValue, eventPlayer) => {
-						const value = _unknownValue as EventValue<"PlayCard">;
+						const value = _unknownValue as EventValue<Event.PlayCard>;
 
 						// Only continue if the player that triggered the event is this card's owner and the played card is a minion.
-						if (eventPlayer !== owner || value.type !== "Minion") {
-							return false;
+						if (eventPlayer !== owner || value.type !== Type.Minion) {
+							return EventListenerMessage.Ignore;
 						}
 
 						// Every time YOU play a MINION, increment `amount` by 1.
@@ -68,7 +77,7 @@ export const blueprint: Blueprint = {
 
 						// If `amount` is less than 10, don't do anything. Return true since it was a success.
 						if (amount < 10) {
-							return true;
+							return EventListenerMessage.Success;
 						}
 
 						// You have now played 10 minions
@@ -85,7 +94,7 @@ export const blueprint: Blueprint = {
 						}
 
 						// Destroy this event listener so it doesn't run again.
-						return "destroy";
+						return EventListenerMessage.Destroy;
 					},
 					-1, // The event listener shouldn't destruct on its own, and should only be manually destroyed.
 				);

--- a/cards/Examples/DIY/1.ts
+++ b/cards/Examples/DIY/1.ts
@@ -1,21 +1,28 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "DIY 1",
 	text: "<b>This is a DIY card, it does not work by default. Battlecry:</b> Give this minion +1/+1.",
 	cost: 0,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["diy"],
+	tags: [CardTag.DIY],
 	id: 61,
 
 	attack: 0,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Give this minion +1/+1.

--- a/cards/Examples/DIY/2.ts
+++ b/cards/Examples/DIY/2.ts
@@ -1,19 +1,26 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	Rarity,
+	SpellSchool,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "DIY 2",
 	text: "<b>This is a DIY card, it does not work by default.</b> Restore 3 health to your hero.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["diy"],
+	tags: [CardTag.DIY],
 	id: 62,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Restore 3 health to the hero.

--- a/cards/Examples/DIY/3.ts
+++ b/cards/Examples/DIY/3.ts
@@ -91,7 +91,7 @@ export const blueprint: Blueprint = {
 				const value = _unknownValue as EventValue<Event.TargetSelected>;
 
 				if (value[0] !== self) {
-					return EventListenerMessage.Ignore;
+					return EventListenerMessage.Skip;
 				}
 
 				// At this point we know that the card wasn't cancelled, since the `TargetSelected` event doesn't fire if the card is cancelled

--- a/cards/Examples/DIY/3.ts
+++ b/cards/Examples/DIY/3.ts
@@ -1,20 +1,32 @@
 // Created by Hand
 
 import { Card } from "@Core/card.js";
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	Event,
+	EventListenerMessage,
+	type EventValue,
+	Rarity,
+	SpellSchool,
+	TargetAlignment,
+	TargetClass,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "DIY 3",
 	text: "<b>This is a DIY card, it does not work by default.</b> Choose a minion to kill.",
 	cost: 0,
-	type: "Spell",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Spell,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["diy"],
+	tags: [CardTag.DIY],
 	id: 63,
 
-	spellSchool: "None",
+	spellSchool: SpellSchool.None,
 
 	async cast(owner, self) {
 		// Choose a minion to kill.
@@ -51,42 +63,42 @@ export const blueprint: Blueprint = {
 
 		// Make sure the parameters are correct
 		game.event.addListener(
-			"TargetSelectionStarts",
+			Event.TargetSelectionStarts,
 			async (_unknownValue) => {
-				const value = _unknownValue as EventValue<"TargetSelectionStarts">;
+				const value = _unknownValue as EventValue<Event.TargetSelectionStarts>;
 
 				// Don't check for `prompt` since there is no correct prompt
 				const [prompt, card, forceSide, forceClass, flags] = value;
 
 				correctParameters =
 					card === self &&
-					forceSide === "any" &&
-					forceClass === "minion" &&
+					forceSide === TargetAlignment.Any &&
+					forceClass === TargetClass.Card &&
 					flags.length === 0;
 
 				// The `TargetSelectionStarts` event fired. This means that the card has a chance of being cancelled.
 				potentiallyCancelled = true;
 
-				return "destroy";
+				return EventListenerMessage.Destroy;
 			},
 			1,
 		);
 
 		// Find the target
 		game.event.addListener(
-			"TargetSelected",
+			Event.TargetSelected,
 			async (_unknownValue) => {
-				const value = _unknownValue as EventValue<"TargetSelected">;
+				const value = _unknownValue as EventValue<Event.TargetSelected>;
 
 				if (value[0] !== self) {
-					return false;
+					return EventListenerMessage.Ignore;
 				}
 
 				// At this point we know that the card wasn't cancelled, since the `TargetSelected` event doesn't fire if the card is cancelled
 				target = value[1] as Card;
 				potentiallyCancelled = false;
 
-				return "destroy";
+				return EventListenerMessage.Destroy;
 			},
 			1,
 		);

--- a/cards/Examples/DIY/4.ts
+++ b/cards/Examples/DIY/4.ts
@@ -1,21 +1,29 @@
 // Created by Hand
 
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	type EventValue,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "DIY 4",
 	text: "<b>This is a DIY card, it does not work by default.</b> Whenever a friendly minion dies, Resurrect it with 1/1 stats.",
 	cost: 0,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["diy"],
+	tags: [CardTag.DIY],
 	id: 64,
 
 	attack: 0,
 	health: 10,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async passive(owner, self, key, _unknownValue, eventPlayer) {
 		// Whenever a minion dies, Resurrect it with 1/1 stats.

--- a/cards/Examples/Test/cant-attack.ts
+++ b/cards/Examples/Test/cant-attack.ts
@@ -1,27 +1,34 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Cant Attack Test",
 	text: "<b>Cant Attack.</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 134,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Cant Attack
 
-		self.addKeyword("Cant Attack");
+		self.addKeyword(Keyword.CantAttack);
 	},
 
 	async test(owner, self) {

--- a/cards/Examples/Test/deathrattle.ts
+++ b/cards/Examples/Test/deathrattle.ts
@@ -2,22 +2,28 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Deathrattle Test",
 	text: "<b>Deathrattle:</b> Summon two 1/1 Sheep.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 72,
 
 	attack: 1,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async deathrattle(owner, self) {
 		// Summon two 1/1 Sheep.

--- a/cards/Examples/Test/disable-heropower.ts
+++ b/cards/Examples/Test/disable-heropower.ts
@@ -1,22 +1,28 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Disable Heropower Test",
 	text: "<i>Disable your hero power.</i>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 136,
 
 	attack: 1,
 	health: 2,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async tick(owner, self) {
 		// Disable your hero power.

--- a/cards/Examples/Test/divine-shield.ts
+++ b/cards/Examples/Test/divine-shield.ts
@@ -1,25 +1,32 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Divine Shield Test",
 	text: "<b>Divine Shield</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 73,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
-		self.addKeyword("Divine Shield");
+		self.addKeyword(Keyword.DivineShield);
 	},
 
 	async test(owner, self) {

--- a/cards/Examples/Test/force-attack.ts
+++ b/cards/Examples/Test/force-attack.ts
@@ -2,22 +2,29 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint, EventValue } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	type EventValue,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Force Attack Test",
 	text: "Whenever a minion attacks, it attacks again.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 137,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Store the attacker / target combo in storage.

--- a/cards/Examples/Test/forgetful.ts
+++ b/cards/Examples/Test/forgetful.ts
@@ -1,27 +1,34 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Forgetful Test",
 	text: "<i>50% Chance to attack the wrong enemy.</i>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 138,
 
 	attack: 5,
 	health: 4,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Forgetful
 
-		self.addKeyword("Forgetful");
+		self.addKeyword(Keyword.Forgetful);
 	},
 
 	async test(owner, self) {

--- a/cards/Examples/Test/frozen.ts
+++ b/cards/Examples/Test/frozen.ts
@@ -1,22 +1,28 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Frozen Test",
 	text: "This is forever <b>Frozen</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 74,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		await self.freeze();

--- a/cards/Examples/Test/immortal.ts
+++ b/cards/Examples/Test/immortal.ts
@@ -1,22 +1,28 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Immortal Test",
 	text: "<i>This minion cannot be removed from the battlefield.</i>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 135,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async remove(owner, self, key) {
 		// This minion cannot be removed from the battlefield.

--- a/cards/Examples/Test/joust.ts
+++ b/cards/Examples/Test/joust.ts
@@ -1,28 +1,34 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Joust Test",
 	text: "<b>Battlecry:</b> Reveal a minion from each player's deck. If yours costs more, gain +1/+1.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 139,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Reveal a minion from each player's deck. If yours costs more, gain +1/+1.
 
 		// Joust. Only allow minion cards to be selected
-		const win = await owner.joust((card) => card.type === "Minion");
+		const win = await owner.joust((card) => card.type === Type.Minion);
 
 		if (!win) {
 			return;

--- a/cards/Examples/Test/summon-on-draw.ts
+++ b/cards/Examples/Test/summon-on-draw.ts
@@ -2,28 +2,35 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Summon On Draw Test",
 	text: "<b>Summon on Draw. Colossal +2.</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 133,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
-		self.addKeyword("Summon On Draw");
+		self.addKeyword(Keyword.SummonOnDraw);
 
 		// Use the preexisting colossal example minions
-		self.addKeyword("Colossal", [
+		self.addKeyword(Keyword.Colossal, [
 			game.cardIds.leftArm46,
 			game.cardIds.null0,
 			game.cardIds.rightArm47,

--- a/cards/Examples/Test/unbreakable.ts
+++ b/cards/Examples/Test/unbreakable.ts
@@ -1,15 +1,15 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, Class, Keyword, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Unbreakable Test",
 	text: "<i>This weapon is unbreakable.</i>",
 	cost: 1,
-	type: "Weapon",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Weapon,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 140,
@@ -19,7 +19,7 @@ export const blueprint: Blueprint = {
 
 	async create(owner, self) {
 		// Add additional fields here
-		self.addKeyword("Unbreakable");
+		self.addKeyword(Keyword.Unbreakable);
 	},
 
 	async test(owner, self) {

--- a/cards/Examples/Test/unlimited-attacks.ts
+++ b/cards/Examples/Test/unlimited-attacks.ts
@@ -1,28 +1,35 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Unlimited Attacks Test",
 	text: "<i>Can attack any number of times.</i>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 141,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Can attack any number of times.
 
 		// This keyword can be added to weapons as well.
-		self.addKeyword("Unlimited Attacks");
+		self.addKeyword(Keyword.UnlimitedAttacks);
 	},
 
 	async test(owner, self) {

--- a/cards/Examples/Unordered/Card References/131-simple.ts
+++ b/cards/Examples/Unordered/Card References/131-simple.ts
@@ -1,22 +1,28 @@
 // Created by Hand
 
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Simple Card Reference Example",
 	text: "The Coin: {coin}",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 131,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async create(owner, self) {
 		// Store a coin for later

--- a/cards/Examples/Unordered/Card References/132-circular.ts
+++ b/cards/Examples/Unordered/Card References/132-circular.ts
@@ -1,21 +1,27 @@
 // Created by Hand
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Circular Card Reference Example",
 	text: "Circular card reference: {card}",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 132,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async placeholders(owner, self) {
 		/*

--- a/cards/Galakrond/111-dragon-claw.ts
+++ b/cards/Galakrond/111-dragon-claw.ts
@@ -1,14 +1,14 @@
 // Created by the Vanilla Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Dragon Claw",
 	text: "",
 	cost: 5,
-	type: "Weapon",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Weapon,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 111,

--- a/cards/Galakrond/112-brewing-storm.ts
+++ b/cards/Galakrond/112-brewing-storm.ts
@@ -1,24 +1,31 @@
 // Created by the Vanilla Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Brewing Storm",
 	text: "<b>Rush</b>",
 	cost: 2,
-	type: "Minion",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 112,
 
 	attack: 2,
 	health: 2,
-	tribe: "Elemental",
+	tribe: MinionTribe.Elemental,
 
 	async create(owner, self) {
 		// Add additional fields here
-		self.addKeyword("Rush");
+		self.addKeyword(Keyword.Rush);
 	},
 };

--- a/cards/Galakrond/Priest/128-heropower.ts
+++ b/cards/Galakrond/Priest/128-heropower.ts
@@ -2,15 +2,15 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond's Wit",
 	text: "Add a random Priest minion to your hand.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Priest"],
-	rarity: "Legendary",
+	type: Type.HeroPower,
+	classes: [Class.Priest],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 128,
@@ -19,8 +19,8 @@ export const blueprint: Blueprint = {
 		// Add a random Priest minion to your hand.
 		const possibleCards = (await Card.all()).filter(
 			(c) =>
-				c.type === "Minion" &&
-				game.functions.card.validateClasses(c.classes, "Priest"),
+				c.type === Type.Minion &&
+				game.functions.card.validateClasses(c.classes, Class.Priest),
 		);
 
 		if (possibleCards.length <= 0) {

--- a/cards/Galakrond/Priest/70-hero.ts
+++ b/cards/Galakrond/Priest/70-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond, the Unspeakable",
 	text: "<b>Battlecry:</b> Destroy {amount} random enemy minion{plural}.",
 	cost: 7,
-	type: "Hero",
-	classes: ["Priest"],
-	rarity: "Legendary",
+	type: Type.Hero,
+	classes: [Class.Priest],
+	rarity: Rarity.Legendary,
 	collectible: true,
-	tags: ["galakrond"],
+	tags: [CardTag.Galakrond],
 	id: 70,
 
 	armor: 5,

--- a/cards/Galakrond/Rogue/125-heropower.ts
+++ b/cards/Galakrond/Rogue/125-heropower.ts
@@ -2,22 +2,22 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond's Guile",
 	text: "Add a <b>Lackey</b> to your hand.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Rogue"],
-	rarity: "Legendary",
+	type: Type.HeroPower,
+	classes: [Class.Rogue],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 125,
 
 	async heropower(owner, self) {
 		// Add a lacky to your hand.
-		const lackey = game.lodash.sample(await Card.allWithTags(["lackey"]));
+		const lackey = game.lodash.sample(await Card.allWithTags([CardTag.Lackey]));
 		if (!lackey) {
 			return;
 		}

--- a/cards/Galakrond/Rogue/67-hero.ts
+++ b/cards/Galakrond/Rogue/67-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond, the Nightmare",
 	text: "<b>Battlecry:</b> Draw {amount} card{plural}. {plural2} costs (0).",
 	cost: 7,
-	type: "Hero",
-	classes: ["Rogue"],
-	rarity: "Legendary",
+	type: Type.Hero,
+	classes: [Class.Rogue],
+	rarity: Rarity.Legendary,
 	collectible: true,
-	tags: ["galakrond"],
+	tags: [CardTag.Galakrond],
 	id: 67,
 
 	armor: 5,

--- a/cards/Galakrond/Shaman/126-heropower.ts
+++ b/cards/Galakrond/Shaman/126-heropower.ts
@@ -2,15 +2,15 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond's Fury",
 	text: "Summon a 2/1 Elemental with <b>Rush</b>.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Shaman"],
-	rarity: "Legendary",
+	type: Type.HeroPower,
+	classes: [Class.Shaman],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 126,

--- a/cards/Galakrond/Shaman/19-windswept-elemental.ts
+++ b/cards/Galakrond/Shaman/19-windswept-elemental.ts
@@ -1,23 +1,30 @@
 // Created by Hand (before the Card Creator Existed)
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Windswept Elemental",
 	text: "<b>Rush</b>",
 	cost: 2,
-	type: "Minion",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 19,
 
 	attack: 2,
 	health: 1,
-	tribe: "Totem",
+	tribe: MinionTribe.Totem,
 
 	async create(owner, self) {
-		self.addKeyword("Rush");
+		self.addKeyword(Keyword.Rush);
 	},
 };

--- a/cards/Galakrond/Shaman/68-hero.ts
+++ b/cards/Galakrond/Shaman/68-hero.ts
@@ -1,17 +1,17 @@
 // Created by the Custom Card Creator
 
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond, the Tempest",
 	text: "<b>Battlecry:</b> Summon two {amount}/{amount} Storms with <b>Rush</b>.{weapon}",
 	cost: 7,
-	type: "Hero",
-	classes: ["Shaman"],
-	rarity: "Legendary",
+	type: Type.Hero,
+	classes: [Class.Shaman],
+	rarity: Rarity.Legendary,
 	collectible: true,
-	tags: ["galakrond"],
+	tags: [CardTag.Galakrond],
 	id: 68,
 
 	armor: 5,

--- a/cards/Galakrond/Warlock/129-heropower.ts
+++ b/cards/Galakrond/Warlock/129-heropower.ts
@@ -2,15 +2,15 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond's Malice",
 	text: "Summon two 1/1 Imps.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Warlock"],
-	rarity: "Legendary",
+	type: Type.HeroPower,
+	classes: [Class.Warlock],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 129,
@@ -34,7 +34,7 @@ export const blueprint: Blueprint = {
 		assert.equal(countImps(), 0);
 
 		// There should be 2 imps when using the hero power
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 		assert.equal(countImps(), 2);
 	},
 };

--- a/cards/Galakrond/Warlock/71-hero.ts
+++ b/cards/Galakrond/Warlock/71-hero.ts
@@ -1,17 +1,24 @@
 // Created by the Custom Card Creator
 
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond, the Wretched",
 	text: "<b>Battlecry:</b> Summon {amount} random Demon{plural}.",
 	cost: 7,
-	type: "Hero",
-	classes: ["Warlock"],
-	rarity: "Legendary",
+	type: Type.Hero,
+	classes: [Class.Warlock],
+	rarity: Rarity.Legendary,
 	collectible: true,
-	tags: ["galakrond"],
+	tags: [CardTag.Galakrond],
 	id: 71,
 
 	armor: 5,
@@ -28,13 +35,13 @@ export const blueprint: Blueprint = {
 				return false;
 			}
 
-			return game.functions.card.matchTribe(card.tribe, "Demon");
+			return game.functions.card.matchTribe(card.tribe, MinionTribe.Demon);
 		};
 
 		for (let i = 0; i < amount; i++) {
 			// Find all demons
 			const possibleCards = (await Card.all()).filter(
-				(c) => c.type === "Minion" && testDemoness(c),
+				(c) => c.type === Type.Minion && testDemoness(c),
 			);
 
 			// Choose a random one

--- a/cards/Galakrond/Warrior/127-heropower.ts
+++ b/cards/Galakrond/Warrior/127-heropower.ts
@@ -1,15 +1,15 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond's Might",
 	text: "Give your hero +3 Attack this turn.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Warrior"],
-	rarity: "Legendary",
+	type: Type.HeroPower,
+	classes: [Class.Warrior],
+	rarity: Rarity.Legendary,
 	collectible: false,
 	tags: [],
 	id: 127,
@@ -22,7 +22,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		assert.equal(owner.attack, 0);
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		assert.equal(owner.attack, 3);
 	},

--- a/cards/Galakrond/Warrior/69-hero.ts
+++ b/cards/Galakrond/Warrior/69-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Galakrond, the Unbreakable",
 	text: "<b>Battlecry:</b> Draw {amount} minion{plural}. Give {plural2} +4/+4.",
 	cost: 7,
-	type: "Hero",
-	classes: ["Warrior"],
-	rarity: "Legendary",
+	type: Type.Hero,
+	classes: [Class.Warrior],
+	rarity: Rarity.Legendary,
 	collectible: true,
-	tags: ["galakrond"],
+	tags: [CardTag.Galakrond],
 	id: 69,
 
 	armor: 5,

--- a/cards/Lackeys/24-ethereal.ts
+++ b/cards/Lackeys/24-ethereal.ts
@@ -2,28 +2,36 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Ethereal Lackey",
 	text: "<b>Battlecry: Discover</b> a spell.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["lackey"],
+	tags: [CardTag.Lackey],
 	id: 24,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Discover a spell.
 
 		// Filter out all cards that aren't spells
-		const pool = (await Card.all()).filter((c) => c.type === "Spell");
+		const pool = (await Card.all()).filter((c) => c.type === Type.Spell);
 		if (pool.length <= 0) {
 			return;
 		}
@@ -47,7 +55,7 @@ export const blueprint: Blueprint = {
 		if (
 			(await Card.all()).filter(
 				(c) =>
-					c.type === "Spell" &&
+					c.type === Type.Spell &&
 					game.functions.card.validateClasses(self.classes, owner.heroClass),
 			).length <= 0
 		) {
@@ -61,7 +69,7 @@ export const blueprint: Blueprint = {
 		for (let i = 0; i < 50; i++) {
 			// Activate the battlecry and get the card from the player's hand.
 			owner.hand = [];
-			await self.activate("battlecry");
+			await self.activate(Ability.Battlecry);
 			const card = owner.hand[0];
 
 			assert.equal(card.type, "Spell");

--- a/cards/Lackeys/25-faceless.ts
+++ b/cards/Lackeys/25-faceless.ts
@@ -2,29 +2,37 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Faceless Lackey",
 	text: "<b>Battlecry:</b> Summon a random 2-Cost minion.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["lackey"],
+	tags: [CardTag.Lackey],
 	id: 25,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Summon a random 2-Cost minion.
 
 		// filter out all cards that aren't 2-cost minions
 		const minions = (await Card.all()).filter(
-			(card) => card.type === "Minion" && card.cost === 2,
+			(card) => card.type === Type.Minion && card.cost === 2,
 		);
 
 		// Choose a random minion
@@ -44,7 +52,7 @@ export const blueprint: Blueprint = {
 		// If there doesn't exist any 2-Cost minions, pass the test
 		if (
 			!(await Card.all()).some(
-				(card) => card.cost === 2 && card.type === "Minion",
+				(card) => card.cost === 2 && card.type === Type.Minion,
 			)
 		) {
 			return;
@@ -54,7 +62,7 @@ export const blueprint: Blueprint = {
 
 		// There shouldn't exist any 2-Cost minions right now.
 		assert(!exists2CostMinion());
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		// There should exist a 2-Cost minion now.
 		assert(exists2CostMinion());

--- a/cards/Lackeys/26-goblin.ts
+++ b/cards/Lackeys/26-goblin.ts
@@ -2,22 +2,32 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	CardTag,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	TargetAlignment,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Goblin Lackey",
 	text: "<b>Battlecry:</b> Give a friendly minion +1 Attack and <b>Rush</b>.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["lackey"],
+	tags: [CardTag.Lackey],
 	id: 26,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Give a friendly minion +1 Attack and Rush.
@@ -26,7 +36,7 @@ export const blueprint: Blueprint = {
 		const target = await game.functions.interact.prompt.targetCard(
 			"Give a friendly minion +1 Attack and Rush",
 			self,
-			"friendly",
+			TargetAlignment.Friendly,
 		);
 
 		// If no target was selected, refund
@@ -38,7 +48,7 @@ export const blueprint: Blueprint = {
 		await target.addStats(1, 0);
 
 		// Add Rush
-		target.addKeyword("Rush");
+		target.addKeyword(Keyword.Rush);
 		return true;
 	},
 
@@ -49,10 +59,10 @@ export const blueprint: Blueprint = {
 
 		// Activate the battlecry, choose the sheep
 		owner.inputQueue = ["1"];
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		// The sheep should have 2 attack and rush
 		assert.equal(sheep.attack, 2);
-		assert(sheep.hasKeyword("Rush"));
+		assert(sheep.hasKeyword(Keyword.Rush));
 	},
 };

--- a/cards/Lackeys/27-kobold.ts
+++ b/cards/Lackeys/27-kobold.ts
@@ -2,22 +2,32 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	TargetAlignment,
+	TargetClass,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Kobold Lackey",
 	text: "<b>Battlecry:</b> Deal 2 damage.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["lackey"],
+	tags: [CardTag.Lackey],
 	id: 27,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Deal 2 damage.
@@ -26,8 +36,8 @@ export const blueprint: Blueprint = {
 		const target = await game.functions.interact.prompt.target(
 			"Deal 2 damage.",
 			self,
-			"any",
-			"any",
+			TargetAlignment.Any,
+			TargetClass.Any,
 		);
 
 		// If no target was selected, refund
@@ -42,7 +52,7 @@ export const blueprint: Blueprint = {
 
 	async test(owner, self) {
 		owner.inputQueue = ["face", "y"];
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		assert.equal(owner.getOpponent().health, 30 - 2);
 		assert.equal(owner.inputQueue, undefined);

--- a/cards/Lackeys/28-witchy.ts
+++ b/cards/Lackeys/28-witchy.ts
@@ -2,22 +2,31 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	TargetAlignment,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Witchy Lackey",
 	text: "<b>Battlecry:</b> Transform a friendly minion into one that costs (1) more.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Neutral"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Neutral],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["lackey"],
+	tags: [CardTag.Lackey],
 	id: 28,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 
 	async battlecry(owner, self) {
 		// Transform a friendly minion into one that costs (1) more.
@@ -26,7 +35,7 @@ export const blueprint: Blueprint = {
 		const target = await game.functions.interact.prompt.targetCard(
 			"Transform a friendly minion into one that costs (1) more.",
 			self,
-			"friendly",
+			TargetAlignment.Friendly,
 		);
 
 		// If no target was selected, refund
@@ -41,7 +50,7 @@ export const blueprint: Blueprint = {
 
 		// Filter minions that cost (1) more than the target
 		const minions = (await Card.all()).filter(
-			(card) => card.type === "Minion" && card.cost === target.cost + 1,
+			(card) => card.type === Type.Minion && card.cost === target.cost + 1,
 		);
 
 		// Choose a random minion from the filtered list.
@@ -75,7 +84,7 @@ export const blueprint: Blueprint = {
 		// If there doesn't exist any 2-Cost minions, pass the test
 		if (
 			!(await Card.all()).some(
-				(card) => card.cost === sheep.cost + 1 && card.type === "Minion",
+				(card) => card.cost === sheep.cost + 1 && card.type === Type.Minion,
 			)
 		) {
 			return;
@@ -83,7 +92,7 @@ export const blueprint: Blueprint = {
 
 		// Activate the battlecry, select the sheep.
 		owner.inputQueue = ["1"];
-		await self.activate("battlecry");
+		await self.activate(Ability.Battlecry);
 
 		// There should now exist a minion with 1 more cost than the sheep.
 		assert(existsMinionWithCost(sheep.cost + 1));

--- a/cards/StartingHeroes/Death Knight/124-heropower.ts
+++ b/cards/StartingHeroes/Death Knight/124-heropower.ts
@@ -2,15 +2,15 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Ghoul Charge",
 	text: "Summon a 1/1 Ghoul with Charge. It dies at end of turn.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Death Knight"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.DeathKnight],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 124,
@@ -32,7 +32,7 @@ export const blueprint: Blueprint = {
 
 		// The minion shouldn't be on the board at first.
 		assert(!lookForMinion());
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The minion should now be on the board.
 		assert(lookForMinion());

--- a/cards/StartingHeroes/Death Knight/14-hero.ts
+++ b/cards/StartingHeroes/Death Knight/14-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "The Lich King",
 	text: "Death knight starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Death Knight"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.DeathKnight],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 14,
 
 	armor: 0,

--- a/cards/StartingHeroes/Death Knight/23-frail-ghoul.ts
+++ b/cards/StartingHeroes/Death Knight/23-frail-ghoul.ts
@@ -1,25 +1,32 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Frail Ghoul",
 	text: "<b>Charge</b> At the end of your turn, this minion dies.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Death Knight"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.DeathKnight],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 23,
 
 	attack: 1,
 	health: 1,
-	tribe: "Undead",
+	tribe: MinionTribe.Undead,
 
 	async create(owner, self) {
-		self.addKeyword("Charge");
+		self.addKeyword(Keyword.Charge);
 	},
 
 	async passive(owner, self, key, value, eventPlayer) {

--- a/cards/StartingHeroes/Demon Hunter/123-heropower.ts
+++ b/cards/StartingHeroes/Demon Hunter/123-heropower.ts
@@ -1,15 +1,15 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Demon Claws",
 	text: "+1 Attack this turn.",
 	cost: 1,
-	type: "Heropower",
-	classes: ["Demon Hunter"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.DemonHunter],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 123,
@@ -24,7 +24,7 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// The player should start with 0 attack
 		assert.equal(owner.attack, 0);
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The player should gain 1 attack
 		assert.equal(owner.attack, 1);

--- a/cards/StartingHeroes/Demon Hunter/13-hero.ts
+++ b/cards/StartingHeroes/Demon Hunter/13-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Illidan Stormrage",
 	text: "Demon hunter starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Demon Hunter"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.DemonHunter],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 13,
 
 	armor: 0,

--- a/cards/StartingHeroes/Druid/115-heropower.ts
+++ b/cards/StartingHeroes/Druid/115-heropower.ts
@@ -1,15 +1,15 @@
 // Created by Hand
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Shapeshift",
 	text: "+1 Attack this turn. +1 Armor.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Druid"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Druid],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 115,
@@ -28,7 +28,7 @@ export const blueprint: Blueprint = {
 		// The player should start with 0 attack
 		assert.equal(owner.attack, 0);
 		assert.equal(owner.armor, 0);
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The player should gain 1 attack
 		assert.equal(owner.attack, 1);

--- a/cards/StartingHeroes/Druid/5-hero.ts
+++ b/cards/StartingHeroes/Druid/5-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Malfurion Stormrage",
 	text: "Druid starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Druid"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Druid],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 5,
 
 	armor: 0,

--- a/cards/StartingHeroes/Hunter/116-heropower.ts
+++ b/cards/StartingHeroes/Hunter/116-heropower.ts
@@ -1,15 +1,15 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Steady Shot",
 	text: "Deal 2 damage to the enemy hero.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Hunter"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Hunter],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 116,
@@ -22,7 +22,7 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// The opponent should have 30 health
 		assert.equal(owner.getOpponent().health, 30);
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The opponent should now have 28 health.
 		assert.equal(owner.getOpponent().health, 30 - 2);

--- a/cards/StartingHeroes/Hunter/6-hero.ts
+++ b/cards/StartingHeroes/Hunter/6-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Rexxar",
 	text: "Hunter starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Hunter"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Hunter],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 6,
 
 	armor: 0,

--- a/cards/StartingHeroes/Mage/114-heropower.ts
+++ b/cards/StartingHeroes/Mage/114-heropower.ts
@@ -2,15 +2,24 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	TargetAlignment,
+	TargetClass,
+	TargetFlag,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Fireblast",
 	text: "Deal 1 damage.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Mage"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Mage],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 114,
@@ -18,13 +27,13 @@ export const blueprint: Blueprint = {
 	async heropower(owner, self) {
 		// Deal 1 damage.
 
-		// Use of `promptTarget` in the `heropower` ability requires the use of the `forceElusive` flag
+		// Use of `prompt.target` in the `heropower` ability requires the use of the `ForceElusive` flag
 		const target = await game.functions.interact.prompt.target(
 			"Deal 1 damage.",
 			self,
-			"any",
-			"any",
-			["forceElusive"],
+			TargetAlignment.Any,
+			TargetClass.Any,
+			[TargetFlag.ForceElusive],
 		);
 
 		// If no target was selected, refund the hero power
@@ -42,7 +51,7 @@ export const blueprint: Blueprint = {
 		assert.equal(owner.getOpponent().health, 30);
 
 		owner.inputQueue = ["face", "y"];
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The opponent should have 29 health.
 		assert.equal(owner.getOpponent().health, 30 - 1);

--- a/cards/StartingHeroes/Mage/4-hero.ts
+++ b/cards/StartingHeroes/Mage/4-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Jaina Proudmoore",
 	text: "Mage starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Mage"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Mage],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 4,
 
 	armor: 0,

--- a/cards/StartingHeroes/Paladin/10-hero.ts
+++ b/cards/StartingHeroes/Paladin/10-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Uther Lightbringer",
 	text: "Paladin starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Paladin"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Paladin],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 10,
 
 	armor: 0,

--- a/cards/StartingHeroes/Paladin/120-heropower.ts
+++ b/cards/StartingHeroes/Paladin/120-heropower.ts
@@ -2,15 +2,15 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Reinforce",
 	text: "Summon a 1/1 Silver Hand Recruit.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Paladin"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Paladin],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 120,
@@ -31,7 +31,7 @@ export const blueprint: Blueprint = {
 
 		// The minion should not exist
 		assert(!checkIfMinionExists());
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The minion should now exist
 		assert(checkIfMinionExists());

--- a/cards/StartingHeroes/Paladin/20-silver-hand-recruit.ts
+++ b/cards/StartingHeroes/Paladin/20-silver-hand-recruit.ts
@@ -1,19 +1,25 @@
 // Created by Hand (before the Card Creator Existed)
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Silver Hand Recruit",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Paladin"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Paladin],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 20,
 
 	attack: 1,
 	health: 1,
-	tribe: "None",
+	tribe: MinionTribe.None,
 };

--- a/cards/StartingHeroes/Priest/118-heropower.ts
+++ b/cards/StartingHeroes/Priest/118-heropower.ts
@@ -2,15 +2,24 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	Class,
+	Rarity,
+	TargetAlignment,
+	TargetClass,
+	TargetFlag,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Lesser Heal",
 	text: "Restore 2 Health.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Priest"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Priest],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 118,
@@ -18,13 +27,13 @@ export const blueprint: Blueprint = {
 	async heropower(owner, self) {
 		// Restore 2 Health.
 
-		// Hero power targets need to use the `forceElusive` flag.
+		// Hero power targets need to use the `ForceElusive` flag.
 		const target = await game.functions.interact.prompt.target(
 			"Restore 2 health.",
 			self,
-			"any",
-			"any",
-			["forceElusive"],
+			TargetAlignment.Any,
+			TargetClass.Any,
+			[TargetFlag.ForceElusive],
 		);
 
 		// If no target was selected, refund the hero power
@@ -41,14 +50,14 @@ export const blueprint: Blueprint = {
 		// Health: 1->3
 		owner.health = 1;
 		owner.inputQueue = ["face", "n"];
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		assert.equal(owner.health, 1 + 2);
 
 		// Health: 29->30 (cap at 30)
 		owner.health = 29;
 		owner.inputQueue = ["face", "n"];
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		assert.equal(owner.health, 30);
 	},

--- a/cards/StartingHeroes/Priest/8-hero.ts
+++ b/cards/StartingHeroes/Priest/8-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Anduin Wrynn",
 	text: "Priest starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Priest"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Priest],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 8,
 
 	armor: 0,

--- a/cards/StartingHeroes/Rogue/12-hero.ts
+++ b/cards/StartingHeroes/Rogue/12-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Valeera Sanguinar",
 	text: "Rogue starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Rogue"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Rogue],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 12,
 
 	armor: 0,

--- a/cards/StartingHeroes/Rogue/122-heropower.ts
+++ b/cards/StartingHeroes/Rogue/122-heropower.ts
@@ -2,15 +2,15 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Dagger Mastery",
 	text: "Equip a 1/2 Dagger.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Rogue"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Rogue],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 122,
@@ -28,7 +28,7 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// The player should not have a weapon
 		assert.equal(owner.weapon, undefined);
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The player should now have the wicked knife weapon
 		assert.ok(owner.weapon);

--- a/cards/StartingHeroes/Rogue/22-wicked-knife.ts
+++ b/cards/StartingHeroes/Rogue/22-wicked-knife.ts
@@ -1,14 +1,14 @@
 // Created by Hand (before the Card Creator Existed)
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Wicked Knife",
 	text: "",
 	cost: 1,
-	type: "Weapon",
-	classes: ["Rogue"],
-	rarity: "Free",
+	type: Type.Weapon,
+	classes: [Class.Rogue],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 22,

--- a/cards/StartingHeroes/Shaman/119-heropower.ts
+++ b/cards/StartingHeroes/Shaman/119-heropower.ts
@@ -2,22 +2,29 @@
 
 import assert from "node:assert";
 import { Card, CardError } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	Ability,
+	type Blueprint,
+	CardTag,
+	Class,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Totemic Call",
 	text: "Summon a random basic Totem.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 119,
 
 	async heropower(owner, self) {
 		// Filter away totem cards that is already on the player's side of the board.
-		const filteredTotemCards = (await Card.allWithTags(["totem"])).filter(
+		const filteredTotemCards = (await Card.allWithTags([CardTag.Totem])).filter(
 			(card) => !owner.board.some((c) => c.id === card.id),
 		);
 
@@ -38,7 +45,7 @@ export const blueprint: Blueprint = {
 	},
 
 	async test(owner, self) {
-		const totemCards = await Card.allWithTags(["totem"]);
+		const totemCards = await Card.allWithTags([CardTag.Totem]);
 		const checkForTotemCard = (amount: number) =>
 			owner.board.filter((card) =>
 				totemCards.map((c) => c.id).includes(card.id),
@@ -48,7 +55,7 @@ export const blueprint: Blueprint = {
 		assert(checkForTotemCard(0));
 
 		for (let index = 1; index <= totemCards.length + 1; index++) {
-			await self.activate("heropower");
+			await self.activate(Ability.HeroPower);
 
 			// If all totem cards are on the board, it shouldn't summon a new one
 			if (index > totemCards.length) {

--- a/cards/StartingHeroes/Shaman/9-hero.ts
+++ b/cards/StartingHeroes/Shaman/9-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Thrall",
 	text: "Shaman starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 9,
 
 	armor: 0,

--- a/cards/StartingHeroes/Shaman/Totems/15-healing-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/15-healing-totem.ts
@@ -2,22 +2,29 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Healing Totem",
 	text: "At the end of your turn, restore 1 Health to all friendly minions.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["totem"],
+	tags: [CardTag.Totem],
 	id: 15,
 
 	attack: 0,
 	health: 2,
-	tribe: "Totem",
+	tribe: MinionTribe.Totem,
 
 	async passive(owner, self, key, value, eventPlayer) {
 		// At the end of your turn, restore 1 Health to all friendly minions.
@@ -28,7 +35,9 @@ export const blueprint: Blueprint = {
 		}
 
 		// Restore 1 Health to all friendly minions
-		for (const card of owner.board.filter((card) => card.type === "Minion")) {
+		for (const card of owner.board.filter(
+			(card) => card.type === Type.Minion,
+		)) {
 			await card.addHealth(1, true);
 		}
 	},

--- a/cards/StartingHeroes/Shaman/Totems/16-searing-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/16-searing-totem.ts
@@ -1,19 +1,26 @@
 // Created by Hand (before the Card Creator Existed)
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Searing Totem",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["totem"],
+	tags: [CardTag.Totem],
 	id: 16,
 
 	attack: 1,
 	health: 1,
-	tribe: "Totem",
+	tribe: MinionTribe.Totem,
 };

--- a/cards/StartingHeroes/Shaman/Totems/17-stoneclaw-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/17-stoneclaw-totem.ts
@@ -1,23 +1,31 @@
 // Created by Hand (before the Card Creator Existed)
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	Keyword,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Stoneclaw Totem",
 	text: "<b>Taunt</b>",
 	cost: 1,
-	type: "Minion",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["totem"],
+	tags: [CardTag.Totem],
 	id: 17,
 
 	attack: 0,
 	health: 2,
-	tribe: "Totem",
+	tribe: MinionTribe.Totem,
 
 	async create(owner, self) {
-		self.addKeyword("Taunt");
+		self.addKeyword(Keyword.Taunt);
 	},
 };

--- a/cards/StartingHeroes/Shaman/Totems/18-strength-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/18-strength-totem.ts
@@ -2,22 +2,29 @@
 
 import assert from "node:assert";
 import { Card } from "@Core/card.js";
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Strength Totem",
 	text: "At the end of your turn, give another friendly minion +1 Attack.",
 	cost: 1,
-	type: "Minion",
-	classes: ["Shaman"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Shaman],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["totem"],
+	tags: [CardTag.Totem],
 	id: 18,
 
 	attack: 0,
 	health: 2,
-	tribe: "Totem",
+	tribe: MinionTribe.Totem,
 
 	async passive(owner, self, key, value, eventPlayer) {
 		// At the end of your turn, give another friendly minion +1 Attack.
@@ -28,7 +35,7 @@ export const blueprint: Blueprint = {
 		}
 
 		// The list that to choose from. Remove this minion from the list
-		const board = owner.board.filter((card) => card.type === "Minion");
+		const board = owner.board.filter((card) => card.type === Type.Minion);
 		game.functions.util.remove(board, self);
 
 		// Choose the random minion

--- a/cards/StartingHeroes/Warlock/11-hero.ts
+++ b/cards/StartingHeroes/Warlock/11-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Gul'dan",
 	text: "Warlock starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Warlock"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Warlock],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 11,
 
 	armor: 0,

--- a/cards/StartingHeroes/Warlock/121-heropower.ts
+++ b/cards/StartingHeroes/Warlock/121-heropower.ts
@@ -1,15 +1,15 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Life Tap",
 	text: "Draw a card and take 2 damage.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Warlock"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Warlock],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 121,
@@ -30,7 +30,7 @@ export const blueprint: Blueprint = {
 		assert.equal(owner.hand.length, 0);
 		assert.equal(owner.health, 30);
 
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The player should now have 1 card in their hand, and 28 health.
 		assert.equal(owner.hand.length, 1);

--- a/cards/StartingHeroes/Warlock/21-draconic-imp.ts
+++ b/cards/StartingHeroes/Warlock/21-draconic-imp.ts
@@ -1,19 +1,25 @@
 // Created by Hand (before the Card Creator Existed)
 
-import type { Blueprint } from "@Game/types.js";
+import {
+	type Blueprint,
+	Class,
+	MinionTribe,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Draconic Imp",
 	text: "",
 	cost: 1,
-	type: "Minion",
-	classes: ["Warlock"],
-	rarity: "Free",
+	type: Type.Minion,
+	classes: [Class.Warlock],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 21,
 
 	attack: 1,
 	health: 1,
-	tribe: "Demon",
+	tribe: MinionTribe.Demon,
 };

--- a/cards/StartingHeroes/Warrior/117-heropower.ts
+++ b/cards/StartingHeroes/Warrior/117-heropower.ts
@@ -1,15 +1,15 @@
 // Created by the Custom Card Creator
 
 import assert from "node:assert";
-import type { Blueprint } from "@Game/types.js";
+import { Ability, type Blueprint, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Armor Up",
 	text: "Gain 2 Armor.",
 	cost: 2,
-	type: "Heropower",
-	classes: ["Warrior"],
-	rarity: "Free",
+	type: Type.HeroPower,
+	classes: [Class.Warrior],
+	rarity: Rarity.Free,
 	collectible: false,
 	tags: [],
 	id: 117,
@@ -24,7 +24,7 @@ export const blueprint: Blueprint = {
 	async test(owner, self) {
 		// The player should have 0 armor
 		assert.equal(owner.armor, 0);
-		await self.activate("heropower");
+		await self.activate(Ability.HeroPower);
 
 		// The player should now have 2 armor
 		assert.equal(owner.armor, 2);

--- a/cards/StartingHeroes/Warrior/7-hero.ts
+++ b/cards/StartingHeroes/Warrior/7-hero.ts
@@ -1,16 +1,16 @@
 // Created by the Custom Card Creator
 
-import type { Blueprint } from "@Game/types.js";
+import { type Blueprint, CardTag, Class, Rarity, Type } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
 	name: "Garrosh Hellscream",
 	text: "Warrior starting hero",
 	cost: 0,
-	type: "Hero",
-	classes: ["Warrior"],
-	rarity: "Free",
+	type: Type.Hero,
+	classes: [Class.Warrior],
+	rarity: Rarity.Free,
 	collectible: false,
-	tags: ["starting_hero"],
+	tags: [CardTag.StartingHero],
 	id: 7,
 
 	armor: 0,

--- a/config.ts
+++ b/config.ts
@@ -26,6 +26,9 @@ export const config: GameConfig = {
 
 		// The maximum amount of cards that is allowed in a hand. Don't go under 4 or the game will crash on start.
 		maxHandLength: 10,
+
+		// If you are a no-fun partypooper, you can set this to `true` to disable all time-based events.
+		disableEvents: false,
 	},
 
 	decks: {

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-import type { GameConfig } from "@Game/types.js";
+import { Event, type GameConfig } from "@Game/types.js";
 
 export const config: GameConfig = {
 	general: {
@@ -238,30 +238,30 @@ export const config: GameConfig = {
 		 * Also, the log files override this list and instead shows every valid key
 		 */
 		whitelistedHistoryKeys: [
-			"HealthRestored",
-			"UnspentMana",
-			"GainOverload",
-			"GainHeroAttack",
-			"TakeDamage",
-			"PlayCard",
-			"SummonCard",
-			"KillCard",
-			"DamageCard",
-			"SilenceCard",
-			"DiscardCard",
-			"TradeCard",
-			"ForgeCard",
-			"FreezeCard",
-			"RevealCard",
-			"Titan",
-			"AddCardToDeck",
-			"AddCardToHand",
-			"DrawCard",
-			"Attack",
-			"HeroPower",
-			"TargetSelectionStarts",
-			"TargetSelected",
-			"CardEvent",
+			Event.HealthRestored,
+			Event.UnspentMana,
+			Event.GainOverload,
+			Event.GainHeroAttack,
+			Event.TakeDamage,
+			Event.PlayCard,
+			Event.SummonCard,
+			Event.KillCard,
+			Event.DamageCard,
+			Event.SilenceCard,
+			Event.DiscardCard,
+			Event.TradeCard,
+			Event.ForgeCard,
+			Event.FreezeCard,
+			Event.RevealCard,
+			Event.Titan,
+			Event.AddCardToDeck,
+			Event.AddCardToHand,
+			Event.DrawCard,
+			Event.Attack,
+			Event.HeroPower,
+			Event.TargetSelectionStarts,
+			Event.TargetSelected,
+			Event.CardEvent,
 		],
 
 		/*
@@ -270,10 +270,10 @@ export const config: GameConfig = {
 		 * The log files override this list and shows the value regardless.
 		 */
 		hideValueHistoryKeys: [
-			"DrawCard",
-			"ForgeCard",
-			"AddCardToHand",
-			"AddCardToDeck",
+			Event.DrawCard,
+			Event.ForgeCard,
+			Event.AddCardToHand,
+			Event.AddCardToDeck,
 		],
 	},
 

--- a/scripts/id/main.ts
+++ b/scripts/id/main.ts
@@ -20,7 +20,13 @@ console.log(
 	"<green>The validate and quit commands are safe to use without issue.</green>\n",
 );
 
-type Commands = "i" | "d" | "v" | "q";
+enum Commands {
+	Increment = "i",
+	Decrement = "d",
+	Validate = "v",
+	Quit = "q",
+}
+
 let running = true;
 
 while (running) {
@@ -29,13 +35,14 @@ while (running) {
 			"What do you want to do? ([i]ncrement, [d]ecrement, [v]alidate, [q]uit): ",
 		)
 	)[0] as Commands;
+
 	if (!func) {
 		await game.pause("<red>Invalid command.</red>\n");
 		continue;
 	}
 
 	func = func.toLowerCase() as Commands;
-	const destructive = ["i", "d"] as Commands[];
+	const destructive = [Commands.Increment, Commands.Decrement];
 
 	if (destructive.includes(func)) {
 		console.error(

--- a/scripts/testcards.ts
+++ b/scripts/testcards.ts
@@ -7,6 +7,7 @@ import process from "node:process";
 import { Card } from "@Core/card.js";
 import { createGame } from "@Core/game.js";
 import type { Player } from "@Core/player.js";
+import { Ability } from "@Game/types.js";
 
 const { game } = createGame();
 const cards = await Card.all(true);
@@ -20,7 +21,7 @@ const cards = await Card.all(true);
  */
 async function testCard(card: Card): Promise<boolean | Error> {
 	try {
-		await card.activate("test");
+		await card.activate(Ability.Test);
 	} catch (error) {
 		if (error instanceof Error) {
 			return error;

--- a/src/core/card.ts
+++ b/src/core/card.ts
@@ -1245,7 +1245,7 @@ export class Card {
 	): Promise<unknown[] | typeof Card.REFUND | false> {
 		/*
 		 * This activates a function
-		 * Example: activate("cast")
+		 * Example: activate(Ability.Cast)
 		 * Do: this.cast.forEach(castFunc => castFunc(owner, card))
 		 * Returns a list of the return values from all the function calls
 		 */

--- a/src/core/card.ts
+++ b/src/core/card.ts
@@ -8,6 +8,7 @@ import {
 	type CardTag,
 	Class,
 	CostType,
+	DeckValidationError,
 	type EnchantmentDefinition,
 	Event,
 	type GameConfig,
@@ -66,7 +67,7 @@ export class Card {
 	type = Type.Undefined;
 
 	/**
-	 * This is the rarity of the card. E.g. "Common" | "Rare" | etc...
+	 * This is the rarity of the card. E.g. Common, Rare, etc...
 	 */
 	rarity = Rarity.Free;
 
@@ -1769,26 +1770,26 @@ export class Card {
 	 *
 	 * @returns Success | Errorcode
 	 */
-	validateForDeck(): true | "class" | "uncollectible" | "runes" {
+	validateForDeck(): DeckValidationError {
 		if (!this.classes.includes(this.owner.heroClass)) {
 			// If it is a neutral card, it is valid
 			if (this.classes.includes(Class.Neutral)) {
 				// Valid
 			} else {
-				return "class";
+				return DeckValidationError.Class;
 			}
 		}
 
 		if (!this.collectible) {
-			return "uncollectible";
+			return DeckValidationError.Uncollectible;
 		}
 
 		// Runes
 		if (this.runes && !this.owner.testRunes(this.runes)) {
-			return "runes";
+			return DeckValidationError.Runes;
 		}
 
-		return true;
+		return DeckValidationError.Success;
 	}
 
 	/**

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -10,6 +10,7 @@ import {
 	type Todo,
 	Type,
 	type UnknownEventValue,
+	UseLocationError,
 } from "@Game/types.js";
 import { resumeTagParsing, stopTagParsing } from "chalk-tags";
 
@@ -100,25 +101,28 @@ export const commands: CommandList = {
 	async use(): Promise<boolean> {
 		// Use location
 		const errorCode = await game.functions.interact.prompt.useLocation();
-
-		if (errorCode === true || errorCode === "refund" || game.player.ai) {
+		if (
+			errorCode === UseLocationError.Success ||
+			errorCode === UseLocationError.Refund ||
+			game.player.ai
+		) {
 			return true;
 		}
 
 		let error: string;
 
 		switch (errorCode) {
-			case "nolocations": {
+			case UseLocationError.NoLocationsFound: {
 				error = "You have no location cards";
 				break;
 			}
 
-			case "invalidtype": {
+			case UseLocationError.InvalidType: {
 				error = "That card is not a location card";
 				break;
 			}
 
-			case "cooldown": {
+			case UseLocationError.Cooldown: {
 				error = "That location is on cooldown";
 				break;
 			}

--- a/src/core/functions/color.ts
+++ b/src/core/functions/color.ts
@@ -1,4 +1,4 @@
-import type { CardRarity } from "@Game/types.js";
+import { Rarity } from "@Game/types.js";
 import { parseTags } from "chalk-tags";
 import stripAnsi from "strip-ansi";
 
@@ -18,31 +18,31 @@ export const colorFunctions = {
 	 * const colored = fromRarity(card.name, card.rarity);
 	 * assert.equal(colored, chalk.yellow("Sheep"));
 	 */
-	fromRarity(text: string, rarity: CardRarity): string {
+	fromRarity(text: string, rarity: Rarity): string {
 		let newText = "";
 
 		switch (rarity) {
-			case "Free": {
+			case Rarity.Free: {
 				newText = text;
 				break;
 			}
 
-			case "Common": {
+			case Rarity.Common: {
 				newText = `<gray>${text}</gray>`;
 				break;
 			}
 
-			case "Rare": {
+			case Rarity.Rare: {
 				newText = `<blue>${text}</blue>`;
 				break;
 			}
 
-			case "Epic": {
+			case Rarity.Epic: {
 				newText = `<bright:magenta>${text}</bright:magenta>`;
 				break;
 			}
 
-			case "Legendary": {
+			case Rarity.Legendary: {
 				newText = `<yellow>${text}</yellow>`;
 				break;
 			}

--- a/src/core/functions/deckcode.ts
+++ b/src/core/functions/deckcode.ts
@@ -1,12 +1,12 @@
 import { Card } from "@Core/card.js";
 import type { Player } from "@Core/player.js";
-import type {
-	CardClass,
-	CardClassNoNeutral,
-	CardLike,
-	FunctionsExportDeckError,
-	GameConfig,
-	VanillaCard,
+import {
+	type CardLike,
+	Class,
+	type FunctionsExportDeckError,
+	type GameConfig,
+	Rarity,
+	type VanillaCard,
 } from "@Game/types.js";
 
 // To decode vanilla deckcodes
@@ -76,16 +76,12 @@ export const deckcodeFunctions = {
 		hero = hero.trim();
 		actualCode = sep[1] + actualCode.split(sep)[1];
 
-		if (
-			!(await game.functions.card.getClasses()).includes(
-				hero as CardClassNoNeutral,
-			)
-		) {
+		if (!(await game.functions.card.getClasses()).includes(hero)) {
 			await panic("INVALIDHERO");
 			return;
 		}
 
-		player.heroClass = hero as CardClass;
+		player.heroClass = game.lodash.startCase(hero) as Class;
 		const runeClass = player.canUseRunes();
 
 		const addRunes = async (runes: string) => {
@@ -263,7 +259,8 @@ export const deckcodeFunctions = {
 			}
 
 			if (
-				(await Card.fromName(cardName, game.player))?.rarity === "Legendary" &&
+				(await Card.fromName(cardName, game.player))?.rarity ===
+					Rarity.Legendary &&
 				amount > localSettings.decks.maxOfOneLegendary
 			) {
 				errorcode = "legendary";
@@ -395,7 +392,7 @@ export const deckcodeFunctions = {
 
 			if (
 				copies > game.config.decks.maxOfOneLegendary &&
-				card.rarity === "Legendary"
+				card.rarity === Rarity.Legendary
 			) {
 				error = {
 					msg: "TooManyLegendaryCopies",
@@ -445,24 +442,25 @@ export const deckcodeFunctions = {
 		};
 
 		// List of vanilla heroes dbfIds
-		const vanillaHeroes: { [key in CardClass]?: number } = {
-			Warrior: 7,
-			Hunter: 31,
-			Druid: 274,
-			Mage: 637,
-			Paladin: 671,
-			Priest: 813,
-			Warlock: 893,
-			Rogue: 930,
-			Shaman: 1066,
-			"Demon Hunter": 56_550,
-			"Death Knight": 78_065,
+		const vanillaHeroes: { [key in Class]?: number } = {
+			[Class.Warrior]: 7,
+			[Class.Hunter]: 31,
+			[Class.Druid]: 274,
+			[Class.Mage]: 637,
+			[Class.Paladin]: 671,
+			[Class.Priest]: 813,
+			[Class.Warlock]: 893,
+			[Class.Rogue]: 930,
+			[Class.Shaman]: 1066,
+			[Class.DemonHunter]: 56_550,
+			[Class.DeathKnight]: 78_065,
 		};
 
 		const codeSplit = code.split(/[[/]/);
 		const heroClass = codeSplit[0].trim();
 
-		const heroClassId = vanillaHeroes[heroClass as CardClass];
+		const heroClassId =
+			vanillaHeroes[game.lodash.startCase(heroClass) as Class];
 		if (!heroClassId) {
 			throw new Error(`Invalid hero class: ${heroClass}`);
 		}
@@ -613,14 +611,14 @@ export const deckcodeFunctions = {
 		)?.cardClass;
 		let heroClassName = game.lodash.capitalize(
 			heroClass?.toString() ?? game.player2.heroClass,
-		) as CardClass;
+		) as string;
 
 		// Wtf hearthstone?
-		if (heroClassName === ("Deathknight" as CardClass)) {
+		if (heroClassName === "Deathknight") {
 			heroClassName = "Death Knight";
 		}
 
-		if (heroClassName === ("Demonhunter" as CardClass)) {
+		if (heroClassName === "Demonhunter") {
 			heroClassName = "Demon Hunter";
 		}
 
@@ -712,7 +710,7 @@ export const deckcodeFunctions = {
 		// Generate runes
 		let runes = "";
 
-		player.heroClass = heroClassName as CardClass;
+		player.heroClass = game.lodash.startCase(heroClassName) as Class;
 
 		if (player.canUseRunes()) {
 			for (const cardAmountObject of newDeck) {

--- a/src/core/functions/deckcode.ts
+++ b/src/core/functions/deckcode.ts
@@ -3,6 +3,7 @@ import type { Player } from "@Core/player.js";
 import {
 	type CardLike,
 	Class,
+	DeckValidationError,
 	type FunctionsExportDeckError,
 	type GameConfig,
 	Rarity,
@@ -173,24 +174,27 @@ export const deckcodeFunctions = {
 
 				const validationError = card.validateForDeck();
 
-				if (!localSettings.decks.validate || validationError === true) {
+				if (
+					!localSettings.decks.validate ||
+					validationError === DeckValidationError.Success
+				) {
 					continue;
 				}
 
 				let error: string;
 
 				switch (validationError) {
-					case "class": {
+					case DeckValidationError.Class: {
 						error = "You have a card from a different class in your deck";
 						break;
 					}
 
-					case "uncollectible": {
+					case DeckValidationError.Uncollectible: {
 						error = "You have an uncollectible card in your deck";
 						break;
 					}
 
-					case "runes": {
+					case DeckValidationError.Runes: {
 						error = "A card does not support your current runes";
 						break;
 					}

--- a/src/core/functions/interact.ts
+++ b/src/core/functions/interact.ts
@@ -12,6 +12,7 @@ import {
 	TargetClass,
 	TargetFlag,
 	Type,
+	UseLocationError,
 } from "@Game/types.js";
 import { parseTags } from "chalk-tags";
 import type { Ai } from "../ai.js";
@@ -534,12 +535,10 @@ const prompt = {
 	 *
 	 * @returns Success
 	 */
-	async useLocation(): Promise<
-		boolean | "nolocations" | "invalidtype" | "cooldown" | "refund"
-	> {
+	async useLocation(): Promise<UseLocationError> {
 		const locations = game.player.board.filter((m) => m.type === Type.Location);
 		if (locations.length <= 0) {
-			return "nolocations";
+			return UseLocationError.NoLocationsFound;
 		}
 
 		const location = await this.targetCard(
@@ -550,19 +549,19 @@ const prompt = {
 		);
 
 		if (!location) {
-			return "refund";
+			return UseLocationError.Refund;
 		}
 
 		if (location.type !== Type.Location) {
-			return "invalidtype";
+			return UseLocationError.InvalidType;
 		}
 
 		if (location.cooldown && location.cooldown > 0) {
-			return "cooldown";
+			return UseLocationError.Cooldown;
 		}
 
 		if ((await location.activate(Ability.Use)) === Card.REFUND) {
-			return "refund";
+			return UseLocationError.Refund;
 		}
 
 		if (location.durability === undefined) {
@@ -571,7 +570,7 @@ const prompt = {
 
 		location.durability -= 1;
 		location.cooldown = location.backups.init.cooldown;
-		return true;
+		return UseLocationError.Success;
 	},
 
 	/**

--- a/src/core/functions/interact.ts
+++ b/src/core/functions/interact.ts
@@ -904,7 +904,7 @@ const print = {
 			);
 		}
 
-		if (game.time.events.anniversary) {
+		if (game.isEventActive("anniversary")) {
 			console.log(
 				`\n<b>[${game.time.year - 2022} YEAR ANNIVERSARY! Enjoy some fun-facts about Hearthstone.js!]</b>`,
 			);
@@ -1074,7 +1074,7 @@ const print = {
 
 		console.log(wallify(finished));
 
-		if (game.time.events.anniversary) {
+		if (game.isEventActive("anniversary")) {
 			console.log(
 				"<i>[Anniversary: The code for the stats above was rewritten 3 times in total]</i>",
 			);

--- a/src/core/functions/util.ts
+++ b/src/core/functions/util.ts
@@ -112,7 +112,7 @@ export const utilFunctions = {
 		game.config = require("../../../config.ts").config as GameConfig;
 
 		if (
-			game.time.events.anniversary &&
+			game.isEventActive("anniversary") &&
 			game.config.general.locale === "en_US"
 		) {
 			game.config.general.locale = "anniversary";

--- a/src/core/functions/util.ts
+++ b/src/core/functions/util.ts
@@ -528,7 +528,7 @@ ${mainContent}
 		}) as fs.Dirent[]) {
 			const fullPath = `${actualPath}/${file.name}`;
 
-			if (file.name === "exports.ts") {
+			if (file.name === "ids.ts") {
 				continue;
 			}
 

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1384,6 +1384,15 @@ export class Game {
 	}
 
 	/**
+	 * Returns if a time-based event is currently active.
+	 *
+	 * @param key The name of the event.
+	 */
+	isEventActive(key: keyof typeof this.time.events): boolean {
+		return this.time.events[key] && !this.config.general.disableEvents;
+	}
+
+	/**
 	 * Broadcast event to event listeners
 	 *
 	 * @param key The name of the event (see `EventKey`)

--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -1,13 +1,16 @@
 import type { Ai } from "@Core/ai.js";
 import { Card } from "@Core/card.js";
 
-import type {
-	CardClass,
-	CardType,
-	EventKey,
-	QuestCallback,
-	QuestType,
-	Target,
+import {
+	Ability,
+	CardTag,
+	Class,
+	Event,
+	Keyword,
+	type QuestCallback,
+	type QuestType,
+	type Target,
+	Type,
 } from "@Game/types.js";
 
 export class Player {
@@ -178,7 +181,7 @@ export class Player {
 	 * assert.equal(player.hero.name, "Priest Starting Hero");
 	 *
 	 * // Activate the hero's hero power. (`Restore 2 Health.`)
-	 * await player.hero.activate("heropower");
+	 * await player.hero.activate(Ability.Heropower);
 	 * ```
 	 */
 	hero: Card;
@@ -186,7 +189,7 @@ export class Player {
 	/**
 	 * The class the player is. This is set to either: Mage, Priest, Warlock, Warrior, ...
 	 */
-	heroClass: CardClass = "Mage";
+	heroClass = Class.Mage;
 
 	/**
 	 * If the player can use their hero power.
@@ -246,7 +249,7 @@ export class Player {
 	 *
 	 * If this player's counter includes "Minion", and this player plays a Minion, it gets countered.
 	 */
-	counter: CardType[] = [];
+	counter: Type[] = [];
 
 	/**
 	 * The secrets that the player has.
@@ -481,7 +484,7 @@ export class Player {
 	async addOverload(overload: number): Promise<boolean> {
 		this.overload += overload;
 
-		await game.event.broadcast("GainOverload", overload, this);
+		await game.event.broadcast(Event.GainOverload, overload, this);
 		return true;
 	}
 
@@ -530,7 +533,7 @@ export class Player {
 			return false;
 		}
 
-		await this.weapon.activate("deathrattle");
+		await this.weapon.activate(Ability.Deathrattle);
 		this.attack -= this.weapon.attack ?? 0;
 
 		await this.weapon.destroy();
@@ -563,7 +566,7 @@ export class Player {
 	async addAttack(amount: number): Promise<boolean> {
 		this.attack += amount;
 
-		await game.event.broadcast("GainHeroAttack", amount, this);
+		await game.event.broadcast(Event.GainHeroAttack, amount, this);
 		return true;
 	}
 
@@ -617,10 +620,10 @@ export class Player {
 
 		this.health -= actualAmount;
 
-		await game.event.broadcast("TakeDamage", actualAmount, this);
+		await game.event.broadcast(Event.TakeDamage, actualAmount, this);
 
 		if (!this.isAlive()) {
-			await game.event.broadcast("FatalDamage", undefined, this);
+			await game.event.broadcast(Event.FatalDamage, undefined, this);
 
 			// This is done to allow secrets to prevent death
 			if (!this.isAlive()) {
@@ -664,7 +667,7 @@ export class Player {
 		this.deck.push(card);
 		this.shuffleDeck();
 
-		await game.event.broadcast("AddCardToDeck", card, this);
+		await game.event.broadcast(Event.AddCardToDeck, card, this);
 		return true;
 	}
 
@@ -679,7 +682,7 @@ export class Player {
 	async addToBottomOfDeck(card: Card): Promise<boolean> {
 		this.deck.unshift(card);
 
-		await game.event.broadcast("AddCardToDeck", card, this);
+		await game.event.broadcast(Event.AddCardToDeck, card, this);
 		return true;
 	}
 
@@ -693,7 +696,7 @@ export class Player {
 	async drawCards(amount: number): Promise<Card[]> {
 		const cards: Card[] = [];
 
-		const unsuppress = game.event.suppress("AddCardToHand");
+		const unsuppress = game.event.suppress(Event.AddCardToHand);
 
 		let drawAmount = amount;
 		for (let i = 0; i < drawAmount; i++) {
@@ -711,16 +714,16 @@ export class Player {
 
 			// Cast on draw
 			if (
-				card.type === "Spell" &&
-				card.hasKeyword("Cast On Draw") &&
-				(await card.activate("cast"))
+				card.type === Type.Spell &&
+				card.hasKeyword(Keyword.CastOnDraw) &&
+				(await card.activate(Ability.Cast))
 			) {
 				drawAmount += 1;
 				continue;
 			}
 
 			// Summon on draw
-			if (card.hasKeyword("Summon On Draw") && card.canBeOnBoard()) {
+			if (card.hasKeyword(Keyword.SummonOnDraw) && card.canBeOnBoard()) {
 				await this.summon(card);
 
 				drawAmount += 1;
@@ -728,7 +731,7 @@ export class Player {
 			}
 
 			await this.addToHand(card);
-			await game.event.broadcast("DrawCard", card, this);
+			await game.event.broadcast(Event.DrawCard, card, this);
 			cards.push(card);
 		}
 
@@ -769,18 +772,18 @@ export class Player {
 		game.functions.util.remove(this.deck, card);
 
 		if (
-			card.type === "Spell" &&
-			card.hasKeyword("Cast On Draw") &&
-			(await card.activate("cast"))
+			card.type === Type.Spell &&
+			card.hasKeyword(Keyword.CastOnDraw) &&
+			(await card.activate(Ability.Cast))
 		) {
 			return undefined;
 		}
 
-		await game.event.withSuppressed("AddCardToHand", async () =>
+		await game.event.withSuppressed(Event.AddCardToHand, async () =>
 			this.addToHand(card),
 		);
 
-		await game.event.broadcast("DrawCard", card, this);
+		await game.event.broadcast(Event.DrawCard, card, this);
 		return card;
 	}
 
@@ -799,7 +802,7 @@ export class Player {
 
 		this.hand.push(card);
 
-		await game.event.broadcast("AddCardToHand", card, this);
+		await game.event.broadcast(Event.AddCardToHand, card, this);
 		return true;
 	}
 
@@ -834,9 +837,9 @@ export class Player {
 		const heroCardId = (
 			await Promise.all(
 				(
-					await Card.allWithTags(["starting_hero"])
+					await Card.allWithTags([CardTag.StartingHero])
 				).map(async (hero) => {
-					const unsuppress = game.event.suppress("CreateCard");
+					const unsuppress = game.event.suppress(Event.CreateCard);
 					const card = await hero.imperfectCopy();
 					unsuppress();
 
@@ -868,18 +871,20 @@ export class Player {
 			return false;
 		}
 
-		if ((await this.hero.heropower?.activate("heropower")) === Card.REFUND) {
+		if (
+			(await this.hero.heropower?.activate(Ability.HeroPower)) === Card.REFUND
+		) {
 			return Card.REFUND;
 		}
 
 		for (const card of this.board) {
-			await card.activate("inspire");
+			await card.activate(Ability.Inspire);
 		}
 
 		this.mana -= this.hero.heropower?.cost ?? 0;
 		this.hasUsedHeroPowerThisTurn = true;
 
-		await game.event.broadcast("HeroPower", this.hero.heropower, this);
+		await game.event.broadcast(Event.HeroPower, this.hero.heropower, this);
 		return true;
 	}
 
@@ -912,14 +917,14 @@ export class Player {
 	 * @returns Whether or not the player can use corpses
 	 */
 	canUseCorpses(): boolean {
-		return ["Death Knight"].includes(this.heroClass);
+		return [Class.DeathKnight].includes(this.heroClass);
 	}
 
 	/**
 	 * @returns Whether or not the player can use runes
 	 */
 	canUseRunes(): boolean {
-		return ["Death Knight"].includes(this.heroClass);
+		return [Class.DeathKnight].includes(this.heroClass);
 	}
 
 	/**
@@ -1032,13 +1037,13 @@ export class Player {
 
 			game.functions.util.remove(mulligan, card);
 
-			await game.event.withSuppressed("DrawCard", async () =>
+			await game.event.withSuppressed(Event.DrawCard, async () =>
 				this.drawCards(1),
 			);
-			await game.event.withSuppressed("AddCardToDeck", async () =>
+			await game.event.withSuppressed(Event.AddCardToDeck, async () =>
 				this.shuffleIntoDeck(card),
 			);
-			await game.event.withSuppressed("DiscardCard", async () =>
+			await game.event.withSuppressed(Event.DiscardCard, async () =>
 				card.discard(),
 			);
 
@@ -1147,7 +1152,7 @@ export class Player {
 	async addQuest(
 		type: "Quest" | "Sidequest" | "Secret",
 		card: Card,
-		key: EventKey,
+		key: Event,
 		amount: number,
 		callback: QuestCallback,
 		next?: number,
@@ -1203,14 +1208,14 @@ export class Player {
 	 * @returns Success
 	 */
 	async invoke(): Promise<boolean> {
-		const isCurrentlyGalakrond = this.hero.tags.includes("galakrond");
+		const isCurrentlyGalakrond = this.hero.tags.includes(CardTag.Galakrond);
 
 		const hasGalakrondInDeck = this.deck.find((c) =>
-			c.tags.includes("galakrond"),
+			c.tags.includes(CardTag.Galakrond),
 		);
 
 		const hasGalakrondInHand = this.hand.find((c) =>
-			c.tags.includes("galakrond"),
+			c.tags.includes(CardTag.Galakrond),
 		);
 
 		if (!hasGalakrondInDeck && !hasGalakrondInHand && !isCurrentlyGalakrond) {
@@ -1218,23 +1223,23 @@ export class Player {
 		}
 
 		for (const card of this.deck) {
-			await card.activate("invoke");
+			await card.activate(Ability.Invoke);
 		}
 
 		for (const card of this.hand) {
-			await card.activate("invoke");
+			await card.activate(Ability.Invoke);
 		}
 
 		for (const card of this.board) {
-			await card.activate("invoke");
+			await card.activate(Ability.Invoke);
 		}
 
 		if (isCurrentlyGalakrond) {
-			await this.hero.heropower?.activate("cast");
+			await this.hero.heropower?.activate(Ability.Cast);
 		} else if (hasGalakrondInDeck) {
-			await hasGalakrondInDeck.heropower?.activate("cast");
+			await hasGalakrondInDeck.heropower?.activate(Ability.Cast);
 		} else if (hasGalakrondInHand) {
-			await hasGalakrondInHand.heropower?.activate("cast");
+			await hasGalakrondInHand.heropower?.activate(Ability.Cast);
 		}
 
 		return true;
@@ -1255,7 +1260,7 @@ export class Player {
 	): Promise<Card[]> {
 		const recruitList = game.lodash
 			.shuffle([...list])
-			.filter((c) => c.type === "Minion" && filterPredicate(c));
+			.filter((c) => c.type === Type.Minion && filterPredicate(c));
 
 		let times = 0;
 		const cards: Card[] = [];
@@ -1327,8 +1332,8 @@ export class Player {
 		this.getOpponent().shuffleDeck();
 
 		// Reveal them to both players
-		await game.event.broadcast("RevealCard", [friendlyCard, "Joust"], this);
-		await game.event.broadcast("RevealCard", [enemyCard, "Joust"], this);
+		await game.event.broadcast(Event.RevealCard, [friendlyCard, "Joust"], this);
+		await game.event.broadcast(Event.RevealCard, [enemyCard, "Joust"], this);
 
 		console.log("\n--- JOUST ---");
 		console.log("Yours: %s", await friendlyCard.readable());
@@ -1377,7 +1382,7 @@ export class Player {
 			return;
 		}
 
-		const list = await Card.allWithTags(["diy"]);
+		const list = await Card.allWithTags([CardTag.DIY]);
 
 		const card = game.lodash.sample(list);
 		if (!card) {

--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -8,7 +8,8 @@ import {
 	Event,
 	Keyword,
 	type QuestCallback,
-	type QuestType,
+	type QuestObject,
+	QuestType,
 	type Target,
 	Type,
 } from "@Game/types.js";
@@ -254,17 +255,17 @@ export class Player {
 	/**
 	 * The secrets that the player has.
 	 */
-	secrets: QuestType[] = [];
+	secrets: QuestObject[] = [];
 
 	/**
 	 * The sidequests that the player has.
 	 */
-	sidequests: QuestType[] = [];
+	sidequests: QuestObject[] = [];
 
 	/**
 	 * The quest that the player has.
 	 */
-	quests: QuestType[] = [];
+	quests: QuestObject[] = [];
 
 	/**
 	 * How much attack/health (+1) the player's next jade golem will have.
@@ -1150,27 +1151,27 @@ export class Player {
 	 * @returns Success
 	 */
 	async addQuest(
-		type: "Quest" | "Sidequest" | "Secret",
+		type: QuestType,
 		card: Card,
 		key: Event,
 		amount: number,
 		callback: QuestCallback,
 		next?: number,
 	): Promise<boolean> {
-		let quests: QuestType[];
+		let quests: QuestObject[];
 
 		switch (type) {
-			case "Quest": {
+			case QuestType.Quest: {
 				quests = this.quests;
 				break;
 			}
 
-			case "Sidequest": {
+			case QuestType.Sidequest: {
 				quests = this.sidequests;
 				break;
 			}
 
-			case "Secret": {
+			case QuestType.Secret: {
 				quests = this.secrets;
 				break;
 			}
@@ -1181,9 +1182,8 @@ export class Player {
 		}
 
 		if (
-			(type.toLowerCase() === "quest" && quests.length > 0) ||
-			((type.toLowerCase() === "secret" ||
-				type.toLowerCase() === "sidequest") &&
+			(type === QuestType.Quest && quests.length > 0) ||
+			((type === QuestType.Secret || type === QuestType.Sidequest) &&
 				(quests.length >= 3 || quests.some((s) => s.name === card.name)))
 		) {
 			await this.addToHand(card);

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -1,6 +1,6 @@
 import type { Card } from "@Core/card.js";
 import type { Player } from "@Core/player.js";
-import type { EventKey, UnknownEventValue } from "@Game/types.js";
+import type { Event, UnknownEventValue } from "@Game/types.js";
 import type { Card as _VanillaCard } from "@hearthstonejs/vanillatypes";
 
 export type VanillaCard = _VanillaCard;
@@ -16,150 +16,170 @@ export type ScoredCard = {
 /**
  * The type of the card.
  */
-export type CardType =
-	| "Minion"
-	| "Spell"
-	| "Weapon"
-	| "Hero"
-	| "Location"
-	| "Heropower"
-	| "Undefined";
-
-/**
- * The class that the card belongs to. (without "Neutral")
- */
-export type CardClassNoNeutral =
-	| "Death Knight"
-	| "Demon Hunter"
-	| "Druid"
-	| "Hunter"
-	| "Mage"
-	| "Paladin"
-	| "Priest"
-	| "Rogue"
-	| "Shaman"
-	| "Warlock"
-	| "Warrior";
+export enum Type {
+	Minion = "Minion",
+	Spell = "Spell",
+	Weapon = "Weapon",
+	Hero = "Hero",
+	Location = "Location",
+	HeroPower = "HeroPower",
+	Undefined = "Undefined",
+}
 
 /**
  * The class that the card belongs to.
  */
-export type CardClass = CardClassNoNeutral | "Neutral";
+export enum Class {
+	Neutral = "Neutral",
+	DeathKnight = "DeathKnight",
+	DemonHunter = "DemonHunter",
+	Druid = "Druid",
+	Hunter = "Hunter",
+	Mage = "Mage",
+	Paladin = "Paladin",
+	Priest = "Priest",
+	Rogue = "Rogue",
+	Shaman = "Shaman",
+	Warlock = "Warlock",
+	Warrior = "Warrior",
+}
 
 /**
  * The rarity of the card.
  */
-export type CardRarity = "Free" | "Common" | "Rare" | "Epic" | "Legendary";
+export enum Rarity {
+	Free = "Free",
+	Common = "Common",
+	Rare = "Rare",
+	Epic = "Epic",
+	Legendary = "Legendary",
+}
 
 /**
  * What the card costs.
  */
-export type CostType = "mana" | "armor" | "health";
+export enum CostType {
+	// NOTE: Use camelCase for these values since it accesses fields of the players.
+	Mana = "mana",
+	Armor = "armor",
+	Health = "health",
+}
 
 /**
  * The school of the spell.
  */
-export type SpellSchool =
-	| "Arcane"
-	| "Fel"
-	| "Fire"
-	| "Frost"
-	| "Holy"
-	| "Nature"
-	| "Shadow"
-	| "None";
+export enum SpellSchool {
+	None = "None",
+	Arcane = "Arcane",
+	Fel = "Fel",
+	Fire = "Fire",
+	Frost = "Frost",
+	Holy = "Holy",
+	Nature = "Nature",
+	Shadow = "Shadow",
+}
 
 /**
  * The tribe of the minion.
  */
-export type MinionTribe =
-	| "Beast"
-	| "Demon"
-	| "Dragon"
-	| "Elemental"
-	| "Mech"
-	| "Murloc"
-	| "Naga"
-	| "Pirate"
-	| "Quilboar"
-	| "Totem"
-	| "Undead"
-	| "All"
-	| "None";
+export enum MinionTribe {
+	None = "None",
+	All = "All",
+	Beast = "Beast",
+	Demon = "Demon",
+	Dragon = "Dragon",
+	Elemental = "Elemental",
+	Mech = "Mech",
+	Murloc = "Murloc",
+	Naga = "Naga",
+	Pirate = "Pirate",
+	Quilboar = "Quilboar",
+	Totem = "Totem",
+	Undead = "Undead",
+}
 
 /**
  * Card keywords.
  */
-export type CardKeyword =
-	| "Divine Shield"
-	| "Dormant"
-	| "Lifesteal"
-	| "Poisonous"
-	| "Reborn"
-	| "Rush"
-	| "Stealth"
-	| "Taunt"
-	| "Tradeable"
-	| "Forge"
-	| "Windfury"
-	| "Outcast"
-	| "Cast On Draw"
-	| "Summon On Draw"
-	| "Unbreakable"
-	| "Unlimited Attacks"
-	| "Charge"
-	| "Mega-Windfury"
-	| "Echo"
-	| "Magnetic"
-	| "Twinspell"
-	| "Elusive"
-	| "Frozen"
-	| "Immune"
-	| "Corrupt"
-	| "Colossal"
-	| "Infuse"
-	| "Cleave"
-	| "Titan"
-	| "Forgetful"
-	| "Cant Attack";
+export enum Keyword {
+	DivineShield = "DivineShield",
+	Dormant = "Dormant",
+	Lifesteal = "Lifesteal",
+	Poisonous = "Poisonous",
+	Reborn = "Reborn",
+	Rush = "Rush",
+	Stealth = "Stealth",
+	Taunt = "Taunt",
+	Tradeable = "Tradeable",
+	Forge = "Forge",
+	Windfury = "Windfury",
+	Outcast = "Outcast",
+	CastOnDraw = "CastOnDraw",
+	SummonOnDraw = "SummonOnDraw",
+	Unbreakable = "Unbreakable",
+	UnlimitedAttacks = "UnlimitedAttacks",
+	Charge = "Charge",
+	MegaWindfury = "MegaWindfury",
+	Echo = "Echo",
+	Magnetic = "Magnetic",
+	Twinspell = "Twinspell",
+	Elusive = "Elusive",
+	Frozen = "Frozen",
+	Immune = "Immune",
+	Corrupt = "Corrupt",
+	Colossal = "Colossal",
+	Infuse = "Infuse",
+	Cleave = "Cleave",
+	Titan = "Titan",
+	Forgetful = "Forgetful",
+	CantAttack = "CantAttack",
+}
 
 /**
- * Card abilities that is from vanilla Hearthstone.
+ * Card tags.
  */
-export type CardAbilityReal =
-	| "adapt"
-	| "battlecry"
-	| "cast"
-	| "combo"
-	| "deathrattle"
-	| "finale"
-	| "frenzy"
-	| "honorablekill"
-	| "infuse"
-	| "inspire"
-	| "invoke"
-	| "outcast"
-	| "overheal"
-	| "overkill"
-	| "passive"
-	| "spellburst"
-	| "startofgame"
-	| "heropower"
-	| "use";
+export enum CardTag {
+	StartingHero = "StartingHero",
+	Galakrond = "Galakrond",
+	Totem = "Totem",
+	Lackey = "Lackey",
+	DIY = "Diy",
+}
 
 /**
  * All Card abilities.
  */
-export type CardAbility =
-	| CardAbilityReal
-	| "placeholders"
-	| "condition"
-	| "remove"
-	| "handpassive"
-	| "tick"
-	| "handtick"
-	| "test"
-	| "create";
+export enum Ability {
+	// NOTE: Use camelCase here since these will be converted to methods.
+	Adapt = "adapt",
+	Battlecry = "battlecry",
+	Cast = "cast",
+	Combo = "combo",
+	Deathrattle = "deathrattle",
+	Finale = "finale",
+	Frenzy = "frenzy",
+	HonorableKill = "honorableKill",
+	Infuse = "infuse",
+	Inspire = "inspire",
+	Invoke = "invoke",
+	Outcast = "outcast",
+	Overheal = "overheal",
+	Overkill = "overkill",
+	Passive = "passive",
+	Spellburst = "spellburst",
+	StartOfGame = "startOfGame",
+	HeroPower = "heropower",
+	Use = "use",
+
+	Placeholders = "placeholders",
+	Condition = "condition",
+	Remove = "remove",
+	HandPassive = "handPassive",
+	Tick = "tick",
+	HandTick = "handTick",
+	Test = "test",
+	Create = "create",
+}
 
 /**
  * Card Enchantment object.
@@ -179,10 +199,10 @@ export type CardBackup = {
 /**
  * The ability of a card.
  */
-export type Ability = (
+export type AbilityCallback = (
 	owner: Player,
 	self: Card,
-	key?: EventKey,
+	key?: Event,
 	_unknownValue?: UnknownEventValue,
 	eventPlayer?: Player,
 ) => Promise<unknown>;
@@ -191,7 +211,7 @@ export type Ability = (
  * The abilities that a blueprint can have. (From CardAbility)
  */
 type BlueprintAbilities = {
-	[Property in CardAbility]?: Ability;
+	[key in Ability]?: AbilityCallback;
 };
 
 /**
@@ -201,7 +221,7 @@ type BlueprintAbilities = {
  * ### This is required for Xs and Ys
  * Then it is required by every card.
  */
-export type Blueprint = {
+export interface Blueprint extends BlueprintAbilities {
 	// Common
 	/** The name of the card. This doesn't have to be unique. */
 	name: string;
@@ -214,13 +234,13 @@ export type Blueprint = {
 	/** How much the card should cost. This is normally in mana. */
 	cost: number;
 	/** The type of the card. For example; "Minion" / "Spell" / "Weapon", etc... */
-	type: CardType;
+	type: Type;
 	/** The classes that the card belongs to. For example; ["Neutral"], ["Mage"], ["Paladin", "Rogue"] */
-	classes: CardClass[];
+	classes: Class[];
 	/** The rarity of the card. This doesn't really do much in this game since there isn't any lootbox mechanics here. Examples of rarities: "Legendary", "Epic", "Free", etc... */
-	rarity: CardRarity;
+	rarity: Rarity;
 	/** The tags of the card. */
-	tags: string[];
+	tags: CardTag[];
 	/** If the card should be allowed in decks / card pools. */
 	collectible: boolean;
 	/**
@@ -290,9 +310,9 @@ export type Blueprint = {
 	 * The hero power card should be of type "Heropower", and its `heropower` ability will be triggered every time the player uses their hero power.
 	 */
 	heropowerId?: number;
-} & BlueprintAbilities;
+}
 
 export type BlueprintWithOptional = Blueprint & {
 	runes?: string;
-	keywords?: CardKeyword[];
+	keywords?: Keyword[];
 };

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,28 +1,28 @@
 import type { Card } from "@Core/card.js";
 import type { Player } from "@Core/player.js";
 import type {
-	CardAbility,
-	SelectTargetAlignment,
-	SelectTargetClass,
-	SelectTargetFlag,
+	Ability,
 	Target,
+	TargetAlignment,
+	TargetClass,
+	TargetFlag,
 } from "@Game/types.js";
 
-export type UnknownEventValue = EventValue<EventKey>;
+export type UnknownEventValue = EventValue<Event>;
 
 /**
  * Game events.
  */
 export type EventManagerEvents = {
 	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-	[key in EventKey]?: [[[any, number]], [[any, number]]];
+	[key in Event]?: [[[any, number]], [[any, number]]];
 };
 
 /**
  * Callback for tick hooks. Used in hookToTick.
  */
 export type TickHookCallback = (
-	key: EventKey,
+	key: Event,
 	value: UnknownEventValue,
 	eventPlayer: Player,
 ) => Promise<void>;
@@ -30,7 +30,12 @@ export type TickHookCallback = (
 /**
  * The event listener callback return value.
  */
-export type EventListenerMessage = boolean | "destroy" | "reset";
+export enum EventListenerMessage {
+	Ignore = "Ignore",
+	Success = "Success",
+	Reset = "Reset",
+	Destroy = "Destroy",
+}
 /**
  * The event listener callback function.
  */
@@ -39,7 +44,7 @@ export type EventListenerCallback = (
 	eventPlayer: Player,
 ) => Promise<EventListenerMessage>;
 
-export type HistoryKey = [EventKey, UnknownEventValue, Player | undefined];
+export type HistoryKey = [Event, UnknownEventValue, Player | undefined];
 
 /**
  * The quest callback used in card blueprints.
@@ -55,7 +60,7 @@ export type QuestCallback = (
 export type QuestType = {
 	name: string;
 	progress: [number, number];
-	key: EventKey;
+	key: Event;
 	value: number;
 	callback: QuestCallback;
 	next?: number;
@@ -64,220 +69,221 @@ export type QuestType = {
 /**
  * Event keys
  */
-export type EventKey =
-	| "FatalDamage"
-	| "EndTurn"
-	| "StartTurn"
-	| "HealthRestored"
-	| "UnspentMana"
-	| "GainOverload"
-	| "GainHeroAttack"
-	| "TakeDamage"
-	| "PlayCard"
-	| "PlayCardUnsafe"
-	| "SummonCard"
-	| "KillCard"
-	| "DamageCard"
-	| "SilenceCard"
-	| "DiscardCard"
-	| "CancelCard"
-	| "TradeCard"
-	| "ForgeCard"
-	| "FreezeCard"
-	| "CreateCard"
-	| "RevealCard"
-	| "Titan"
-	| "AddCardToDeck"
-	| "AddCardToHand"
-	| "DrawCard"
-	| "SpellDealsDamage"
-	| "Attack"
-	| "HeroPower"
-	| "TargetSelectionStarts"
-	| "TargetSelected"
-	| "CardEvent"
-	| "Dummy"
-	| "Eval"
-	| "Input"
-	| "GameLoop";
+export enum Event {
+	FatalDamage = "FatalDamage",
+	EndTurn = "EndTurn",
+	StartTurn = "StartTurn",
+	HealthRestored = "HealthRestored",
+	UnspentMana = "UnspentMana",
+	GainOverload = "GainOverload",
+	GainHeroAttack = "GainHeroAttack",
+	TakeDamage = "TakeDamage",
+	PlayCard = "PlayCard",
+	PlayCardUnsafe = "PlayCardUnsafe",
+	SummonCard = "SummonCard",
+	KillCard = "KillCard",
+	DamageCard = "DamageCard",
+	SilenceCard = "SilenceCard",
+	DiscardCard = "DiscardCard",
+	CancelCard = "CancelCard",
+	TradeCard = "TradeCard",
+	ForgeCard = "ForgeCard",
+	FreezeCard = "FreezeCard",
+	CreateCard = "CreateCard",
+	RevealCard = "RevealCard",
+	Titan = "Titan",
+	AddCardToDeck = "AddCardToDeck",
+	AddCardToHand = "AddCardToHand",
+	DrawCard = "DrawCard",
+	SpellDealsDamage = "SpellDealsDamage",
+	Attack = "Attack",
+	HeroPower = "HeroPower",
+	TargetSelectionStarts = "TargetSelectionStarts",
+	TargetSelected = "TargetSelected",
+	CardEvent = "CardEvent",
+	Dummy = "Dummy",
+	Eval = "Eval",
+	Input = "Input",
+	GameLoop = "GameLoop",
+}
 
 /**
  * Event values
  */
-export type EventValue<Key extends EventKey> =
+export type EventValue<Key extends Event> =
 	/**
 	 * This is always null.
 	 */
-	Key extends "FatalDamage"
+	Key extends Event.FatalDamage
 		? undefined
 		: /**
 			 * The current turn (before turn counter increment)
 			 */
-			Key extends "EndTurn"
+			Key extends Event.EndTurn
 			? number
 			: /**
 				 * The current turn (after turn counter increment)
 				 */
-				Key extends "StartTurn"
+				Key extends Event.StartTurn
 				? number
 				: /**
 					 * The amount of health after restore
 					 */
-					Key extends "HealthRestored"
+					Key extends Event.HealthRestored
 					? number
 					: /**
 						 * The amount of mana the player has left
 						 */
-						Key extends "UnspentMana"
+						Key extends Event.UnspentMana
 						? number
 						: /**
 							 * The amount of overload gained
 							 */
-							Key extends "GainOverload"
+							Key extends Event.GainOverload
 							? number
 							: /**
 								 * The amount of hero attack gained
 								 */
-								Key extends "GainHeroAttack"
+								Key extends Event.GainHeroAttack
 								? number
 								: /**
 									 * The player that was dealt the damage, The amount of damage taken
 									 */
-									Key extends "TakeDamage"
+									Key extends Event.TakeDamage
 									? number
 									: /**
 										 * The card that was played. (This gets triggered after the text of the card)
 										 */
-										Key extends "PlayCard"
+										Key extends Event.PlayCard
 										? Card
 										: /**
 											 * The card that was played. (This gets triggered before the text of the card, which means it also gets triggered before the cancelling logic. So you have to handle cards being cancelled.)
 											 */
-											Key extends "PlayCardUnsafe"
+											Key extends Event.PlayCardUnsafe
 											? Card
 											: /**
 												 * The card that was summoned
 												 */
-												Key extends "SummonCard"
+												Key extends Event.SummonCard
 												? Card
 												: /**
 													 * The card that was killed
 													 */
-													Key extends "KillCard"
+													Key extends Event.KillCard
 													? Card
 													: /**
 														 * The card that was damaged, and the amount of damage
 														 */
-														Key extends "DamageCard"
+														Key extends Event.DamageCard
 														? [Card, number]
 														: /**
 															 * The card that was silenced
 															 */
-															Key extends "SilenceCard"
+															Key extends Event.SilenceCard
 															? Card
 															: /**
 																 * The card that was discarded
 																 */
-																Key extends "DiscardCard"
+																Key extends Event.DiscardCard
 																? Card
 																: /**
 																	 * The card that was cancelled, and the ability that was cancelled
 																	 */
-																	Key extends "CancelCard"
-																	? [Card, CardAbility]
+																	Key extends Event.CancelCard
+																	? [Card, Ability]
 																	: /**
 																		 * The card that was traded
 																		 */
-																		Key extends "TradeCard"
+																		Key extends Event.TradeCard
 																		? Card
 																		: /**
 																			 * The card that was forged
 																			 */
-																			Key extends "ForgeCard"
+																			Key extends Event.ForgeCard
 																			? Card
 																			: /**
 																				 * The card that was frozen
 																				 */
-																				Key extends "FreezeCard"
+																				Key extends Event.FreezeCard
 																				? Card
 																				: /**
 																					 * The card that was created
 																					 */
-																					Key extends "CreateCard"
+																					Key extends Event.CreateCard
 																					? Card
 																					: /**
 																						 * The card that was revealed, the reason for the reveal
 																						 */
-																						Key extends "RevealCard"
+																						Key extends Event.RevealCard
 																						? [Card, string]
 																						: /**
 																							 * The titan card, the ability that was used
 																							 */
-																							Key extends "Titan"
+																							Key extends Event.Titan
 																							? [Card, Card]
 																							: /**
 																								 * The card that was added to the deck
 																								 */
-																								Key extends "AddCardToDeck"
+																								Key extends Event.AddCardToDeck
 																								? Card
 																								: /**
 																									 * The card that was added to the hand
 																									 */
-																									Key extends "AddCardToHand"
+																									Key extends Event.AddCardToHand
 																									? Card
 																									: /**
 																										 * The card that was drawn
 																										 */
-																										Key extends "DrawCard"
+																										Key extends Event.DrawCard
 																										? Card
 																										: /**
 																											 * The target, and the amount of damage
 																											 */
-																											Key extends "SpellDealsDamage"
+																											Key extends Event.SpellDealsDamage
 																											? [Target, number]
 																											: /**
 																												 * The attacker, and the target
 																												 */
-																												Key extends "Attack"
+																												Key extends Event.Attack
 																												? [Target, Target]
 																												: /**
 																													 * The hero power card
 																													 */
-																													Key extends "HeroPower"
+																													Key extends Event.HeroPower
 																													? Card
 																													: /**
 																														 * The card, some information about the event
 																														 */
-																														Key extends "CardEvent"
+																														Key extends Event.CardEvent
 																														? [Card, string]
 																														: /**
 																															 * The code to evaluate
 																															 */
-																															Key extends "Eval"
+																															Key extends Event.Eval
 																															? string
 																															: /**
 																																 * The input
 																																 */
-																																Key extends "Input"
+																																Key extends Event.Input
 																																? string
 																																: /**
 																																	 * The prompt, the card that requested target selection, the alignment that the target should be, the class of the target (hero | card), and the flags (if any).
 																																	 */
-																																	Key extends "TargetSelectionStarts"
+																																	Key extends Event.TargetSelectionStarts
 																																	? [
 																																			string,
 																																			(
 																																				| Card
 																																				| undefined
 																																			),
-																																			SelectTargetAlignment,
-																																			SelectTargetClass,
-																																			SelectTargetFlag[],
+																																			TargetAlignment,
+																																			TargetClass,
+																																			TargetFlag[],
 																																		]
 																																	: /**
 																																		 * The card that requested target selection, and the target
 																																		 */
-																																		Key extends "TargetSelected"
+																																		Key extends Event.TargetSelected
 																																		? [
 																																				(
 																																					| Card

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -31,7 +31,7 @@ export type TickHookCallback = (
  * The event listener callback return value.
  */
 export enum EventListenerMessage {
-	Ignore = "Ignore",
+	Skip = "Skip",
 	Success = "Success",
 	Reset = "Reset",
 	Destroy = "Destroy",
@@ -46,18 +46,24 @@ export type EventListenerCallback = (
 
 export type HistoryKey = [Event, UnknownEventValue, Player | undefined];
 
+export enum QuestType {
+	Quest = "Quest",
+	Sidequest = "Sidequest",
+	Secret = "Secret",
+}
+
 /**
  * The quest callback used in card blueprints.
  */
 export type QuestCallback = (
 	value: UnknownEventValue,
 	done: boolean,
-) => Promise<boolean>;
+) => Promise<EventListenerMessage>;
 
 /**
  * The backend of a quest.
  */
-export type QuestType = {
+export type QuestObject = {
 	name: string;
 	progress: [number, number];
 	key: Event;

--- a/src/types/other.ts
+++ b/src/types/other.ts
@@ -6,8 +6,8 @@ import type { Blueprint, Event } from "@Game/types.js";
  * Game.play return value
  */
 export enum GamePlayCardReturn {
-	Invalid = "Invalid",
 	Success = "Success",
+	Invalid = "Invalid",
 	Cost = "Cost",
 	Traded = "Traded",
 	Forged = "Forged",
@@ -22,8 +22,8 @@ export enum GamePlayCardReturn {
  * Attack return value
  */
 export enum GameAttackReturn {
-	Invalid = "Invalid",
 	Success = "Success",
+	Invalid = "Invalid",
 	DivineShield = "DivineShield",
 	Taunt = "Taunt",
 	Stealth = "Stealth",
@@ -37,6 +37,13 @@ export enum GameAttackReturn {
 	Immune = "Immune",
 	Dormant = "Dormant",
 	Titan = "Titan",
+}
+
+export enum DeckValidationError {
+	Success = "Success",
+	Class = "Class",
+	Uncollectible = "Uncollectible",
+	Runes = "Runes",
 }
 
 /**
@@ -84,6 +91,14 @@ export enum TargetClass {
 export enum TargetFlag {
 	AllowLocations = "AllowLocations",
 	ForceElusive = "ForceElusive",
+}
+
+export enum UseLocationError {
+	Success = "Success",
+	NoLocationsFound = "NoLocationsFound",
+	InvalidType = "InvalidType",
+	Cooldown = "Cooldown",
+	Refund = "Refund",
 }
 
 export type CommandList = Record<

--- a/src/types/other.ts
+++ b/src/types/other.ts
@@ -151,6 +151,7 @@ export type GameConfig = {
 		topicBranchWarning: boolean;
 		maxBoardSpace: number;
 		maxHandLength: number;
+		disableEvents: boolean;
 	};
 
 	decks: {

--- a/src/types/other.ts
+++ b/src/types/other.ts
@@ -1,41 +1,43 @@
 import type { Card } from "@Core/card.js";
 import type { Player } from "@Core/player.js";
-import type { Blueprint, EventKey } from "@Game/types.js";
+import type { Blueprint, Event } from "@Game/types.js";
 
 /**
- * Game.PlayCard return value
+ * Game.play return value
  */
-export type GamePlayCardReturn =
-	| true
-	| "cost"
-	| "traded"
-	| "forged"
-	| "space"
-	| "magnetize"
-	| "colossal"
-	| "refund"
-	| "counter"
-	| "invalid";
+export enum GamePlayCardReturn {
+	Invalid = "Invalid",
+	Success = "Success",
+	Cost = "Cost",
+	Traded = "Traded",
+	Forged = "Forged",
+	Space = "Space",
+	Magnetize = "Magnetize",
+	Colossal = "Colossal",
+	Refund = "Refund",
+	Counter = "Counter",
+}
 
 /**
  * Attack return value
  */
-export type GameAttackReturn =
-	| true
-	| "divineshield"
-	| "taunt"
-	| "stealth"
-	| "frozen"
-	| "playernoattack"
-	| "noattack"
-	| "playerhasattacked"
-	| "hasattacked"
-	| "sleepy"
-	| "cantattackhero"
-	| "immune"
-	| "dormant"
-	| "titan"
-	| "invalid";
+export enum GameAttackReturn {
+	Invalid = "Invalid",
+	Success = "Success",
+	DivineShield = "DivineShield",
+	Taunt = "Taunt",
+	Stealth = "Stealth",
+	Frozen = "Frozen",
+	PlayerNoAttack = "PlayerNoAttack",
+	CardNoAttack = "CardNoAttack",
+	PlayerHasAttacked = "PlayerHasAttacked",
+	CardHasAttacked = "CardHasAttacked",
+	Sleepy = "Sleepy",
+	CantAttackHero = "CantAttackHero",
+	Immune = "Immune",
+	Dormant = "Dormant",
+	Titan = "Titan",
+}
 
 /**
  * ExportDeck error return value
@@ -48,23 +50,41 @@ export type FunctionsExportDeckError =
 			recoverable: boolean;
 	  };
 
+export enum AiCalcMoveMessage {
+	End = "End",
+	Attack = "Attack",
+	HeroPower = "HeroPower",
+	Use = "Use",
+}
+
 /**
  * CalcMove return value
  */
-export type AiCalcMoveOption = Card | "hero power" | "attack" | "use" | "end";
+export type AiCalcMoveOption = Card | AiCalcMoveMessage;
 
 /**
  * promptTarget alignment
  */
-export type SelectTargetAlignment = "friendly" | "enemy" | "any";
+export enum TargetAlignment {
+	Friendly = "Friendly",
+	Enemy = "Enemy",
+	Any = "Any",
+}
 /**
  * promptTarget class
  */
-export type SelectTargetClass = "hero" | "minion" | "any";
+export enum TargetClass {
+	Player = "Player",
+	Card = "Card",
+	Any = "Any",
+}
 /**
  * promptTarget flags
  */
-export type SelectTargetFlag = "allowLocations" | "forceElusive";
+export enum TargetFlag {
+	AllowLocations = "AllowLocations",
+	ForceElusive = "ForceElusive",
+}
 
 export type CommandList = Record<
 	string,
@@ -161,8 +181,8 @@ export type GameConfig = {
 
 		forgetfulRandomTargetFailAmount: number;
 
-		whitelistedHistoryKeys: EventKey[];
-		hideValueHistoryKeys: EventKey[];
+		whitelistedHistoryKeys: Event[];
+		hideValueHistoryKeys: Event[];
 	};
 
 	info: {

--- a/test/src/core/functions/card.test.ts
+++ b/test/src/core/functions/card.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { cardFunctions } from "@Core/functions/card.js";
+import { Class, MinionTribe } from "@Game/types.js";
 
 /*
  * Need to create a game in case the functions need it
@@ -17,19 +18,33 @@ describe("src/core/functions/card", () => {
 	});
 
 	test("validateClasses", async () => {
-		expect(cardFunctions.validateClasses(["Mage"], "Druid")).toEqual(false);
-		expect(cardFunctions.validateClasses(["Mage"], "Mage")).toEqual(true);
-		expect(cardFunctions.validateClasses(["Mage", "Druid"], "Druid")).toEqual(
+		expect(cardFunctions.validateClasses([Class.Mage], Class.Druid)).toEqual(
+			false,
+		);
+		expect(cardFunctions.validateClasses([Class.Mage], Class.Mage)).toEqual(
 			true,
 		);
-		expect(cardFunctions.validateClasses(["Neutral"], "Druid")).toEqual(true);
+		expect(
+			cardFunctions.validateClasses([Class.Mage, Class.Druid], Class.Druid),
+		).toEqual(true);
+		expect(cardFunctions.validateClasses([Class.Neutral], Class.Druid)).toEqual(
+			true,
+		);
 	});
 
 	test("matchTribe", async () => {
-		expect(cardFunctions.matchTribe("Beast", "Demon")).toEqual(false);
-		expect(cardFunctions.matchTribe("Beast", "Beast")).toEqual(true);
-		expect(cardFunctions.matchTribe("All", "Beast")).toEqual(true);
-		expect(cardFunctions.matchTribe("Beast", "All")).toEqual(true);
+		expect(
+			cardFunctions.matchTribe(MinionTribe.Beast, MinionTribe.Demon),
+		).toEqual(false);
+		expect(
+			cardFunctions.matchTribe(MinionTribe.Beast, MinionTribe.Beast),
+		).toEqual(true);
+		expect(
+			cardFunctions.matchTribe(MinionTribe.All, MinionTribe.Beast),
+		).toEqual(true);
+		expect(
+			cardFunctions.matchTribe(MinionTribe.Beast, MinionTribe.All),
+		).toEqual(true);
 	});
 
 	test.todo("runBlueprintValidator", async () => {

--- a/test/src/core/functions/color.test.ts
+++ b/test/src/core/functions/color.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { colorFunctions } from "@Core/functions/color.js";
 import { createGame } from "@Core/game.js";
+import { Rarity } from "@Game/types.js";
 import { stopTagParsing } from "chalk-tags";
 
 /*
@@ -14,21 +15,21 @@ describe("src/core/functions/color", () => {
 		// Disable parsing tags so the output from `fromRarity` is easier to parse.
 		stopTagParsing();
 
-		expect(colorFunctions.fromRarity("Test01", "Free")).toEqual("Test01");
+		expect(colorFunctions.fromRarity("Test01", Rarity.Free)).toEqual("Test01");
 
-		expect(colorFunctions.fromRarity("Test02", "Common")).toEqual(
+		expect(colorFunctions.fromRarity("Test02", Rarity.Common)).toEqual(
 			"<gray>Test02</gray>",
 		);
 
-		expect(colorFunctions.fromRarity("Test03", "Rare")).toEqual(
+		expect(colorFunctions.fromRarity("Test03", Rarity.Rare)).toEqual(
 			"<blue>Test03</blue>",
 		);
 
-		expect(colorFunctions.fromRarity("Test04", "Epic")).toEqual(
+		expect(colorFunctions.fromRarity("Test04", Rarity.Epic)).toEqual(
 			"<bright:magenta>Test04</bright:magenta>",
 		);
 
-		expect(colorFunctions.fromRarity("Test05", "Legendary")).toEqual(
+		expect(colorFunctions.fromRarity("Test05", Rarity.Legendary)).toEqual(
 			"<yellow>Test05</yellow>",
 		);
 

--- a/tools/cardcreator/class.ts
+++ b/tools/cardcreator/class.ts
@@ -1,5 +1,11 @@
 import { createGame } from "@Core/game.js";
-import type { Blueprint, CardClass, CardRarity } from "@Game/types.js";
+import {
+	type Blueprint,
+	CardTag,
+	type Class,
+	Rarity,
+	Type,
+} from "@Game/types.js";
 import * as lib from "./lib.js";
 
 const { game } = createGame();
@@ -54,12 +60,12 @@ export async function main(
 		name: heroName,
 		text: `${game.lodash.capitalize(className)} starting hero`,
 		cost: 0,
-		type: "Hero",
+		type: Type.Hero,
 		// We do +2 since the hero card will be created first (+1), then the heropower (+1)
-		classes: [className] as CardClass[],
-		rarity: "Free" as CardRarity,
+		classes: [game.lodash.startCase(className) as Class],
+		rarity: Rarity.Free,
 		collectible: false,
-		tags: ["starting_hero"],
+		tags: [CardTag.StartingHero],
 		// This will be overwritten by the library
 		id: 0,
 
@@ -71,9 +77,9 @@ export async function main(
 		name: hpName,
 		text: hpText,
 		cost: game.lodash.parseInt(hpCost),
-		type: "Heropower",
-		classes: [className] as CardClass[],
-		rarity: "Free" as CardRarity,
+		type: Type.HeroPower,
+		classes: [game.lodash.startCase(className) as Class],
+		rarity: Rarity.Free,
 		collectible: false,
 		tags: [],
 		// This will be overwritten by the library

--- a/tools/cardcreator/class.ts
+++ b/tools/cardcreator/class.ts
@@ -16,7 +16,7 @@ const { game } = createGame();
  */
 export async function main(
 	debug = false,
-	overrideType?: lib.CcType,
+	overrideType?: lib.CCType,
 ): Promise<void> {
 	const watermark = () => {
 		game.functions.interact.cls();
@@ -86,7 +86,7 @@ export async function main(
 		id: 0,
 	};
 
-	let cctype: lib.CcType = "Class";
+	let cctype: lib.CCType = lib.CCType.Class;
 	if (overrideType) {
 		cctype = overrideType;
 	}

--- a/tools/cardcreator/custom.ts
+++ b/tools/cardcreator/custom.ts
@@ -2,19 +2,19 @@ import { createGame } from "@Core/game.js";
 import type {
 	Blueprint,
 	BlueprintWithOptional,
-	CardClass,
-	CardKeyword,
-	CardRarity,
-	CardType,
+	Class,
+	Keyword,
 	MinionTribe,
+	Rarity,
 	SpellSchool,
+	Type,
 } from "@Game/types.js";
 import * as lib from "./lib.js";
 
 const { player1, game } = createGame();
 
 let shouldExit = false;
-let type: CardType;
+let type: Type;
 
 /**
  * Asks the user a question and returns the result.
@@ -93,8 +93,8 @@ async function common(): Promise<BlueprintWithOptional> {
 	const name = await input("Name: ");
 	const text = await input("Text: ");
 	const cost = game.lodash.parseInt(await input("Cost: "));
-	const classes = (await input("Classes: ")) as CardClass;
-	const rarity = (await input("Rarity: ")) as CardRarity;
+	const classes = game.lodash.startCase(await input("Classes: ")) as Class;
+	const rarity = game.lodash.startCase(await input("Rarity: ")) as Rarity;
 	const keywords = await input("Keywords: ");
 
 	player1.heroClass = classes;
@@ -104,9 +104,11 @@ async function common(): Promise<BlueprintWithOptional> {
 		runes = await input("Runes: ");
 	}
 
-	let realKeywords: CardKeyword[] | undefined;
+	let realKeywords: Keyword[] | undefined;
 	if (keywords) {
-		realKeywords = keywords.split(", ") as CardKeyword[];
+		realKeywords = keywords
+			.split(", ")
+			.map((k) => game.lodash.startCase(k) as Keyword);
 	}
 
 	return {
@@ -124,13 +126,15 @@ async function common(): Promise<BlueprintWithOptional> {
 	};
 }
 
-const cardTypeFunctions: { [x in CardType]: () => Promise<Blueprint> } = {
+const cardTypeFunctions: {
+	[x in Type]: () => Promise<Blueprint>;
+} = {
 	async Minion(): Promise<Blueprint> {
 		const card = await common();
 
 		const attack = game.lodash.parseInt(await input("Attack: "));
 		const health = game.lodash.parseInt(await input("Health: "));
-		const tribe = (await input("Tribe: ")) as MinionTribe;
+		const tribe = game.lodash.startCase(await input("Tribe: ")) as MinionTribe;
 
 		return applyCard({
 			...card,
@@ -143,7 +147,9 @@ const cardTypeFunctions: { [x in CardType]: () => Promise<Blueprint> } = {
 	async Spell(): Promise<Blueprint> {
 		const card = await common();
 
-		const spellSchool = (await input("Spell School: ")) as SpellSchool;
+		const spellSchool = game.lodash.startCase(
+			await input("Spell School: "),
+		) as SpellSchool;
 
 		return applyCard({
 			...card,
@@ -200,7 +206,7 @@ const cardTypeFunctions: { [x in CardType]: () => Promise<Blueprint> } = {
 		});
 	},
 
-	async Heropower(): Promise<Blueprint> {
+	async HeroPower(): Promise<Blueprint> {
 		const card = await common();
 
 		return applyCard(card);
@@ -228,7 +234,7 @@ export async function main(
 	console.log("type 'back' at any step to cancel.\n");
 
 	// Ask the user for the type of card they want to make
-	type = game.lodash.startCase(await input("Type: ")) as CardType;
+	type = game.lodash.startCase(await input("Type: ")) as Type;
 	if (shouldExit) {
 		return false;
 	}

--- a/tools/cardcreator/custom.ts
+++ b/tools/cardcreator/custom.ts
@@ -1,9 +1,9 @@
 import { createGame } from "@Core/game.js";
-import type {
-	Blueprint,
-	BlueprintWithOptional,
+import {
+	type Blueprint,
+	type BlueprintWithOptional,
 	Class,
-	Keyword,
+	type Keyword,
 	MinionTribe,
 	Rarity,
 	SpellSchool,
@@ -44,16 +44,21 @@ function applyCard(_card: BlueprintWithOptional): Blueprint {
 		let [key, value] = entry;
 
 		// These are the required fields and their default values.
-		const defaults = {
+		const defaults: Blueprint = {
+			type: Type.Undefined,
 			name: "CHANGE THIS",
 			text: "",
 			cost: 0,
-			classes: ["Neutral"],
-			rarity: "Free",
+			classes: [Class.Neutral],
+			rarity: Rarity.Free,
+			collectible: false,
+			tags: [],
+			id: 0,
+
 			attack: 1,
 			health: 1,
-			tribe: "None",
-			spellSchool: "None",
+			tribe: MinionTribe.None,
+			spellSchool: SpellSchool.None,
 			armor: 5,
 			heropowerId: game.cardIds.null0,
 			durability: 2,
@@ -93,15 +98,15 @@ async function common(): Promise<BlueprintWithOptional> {
 	const name = await input("Name: ");
 	const text = await input("Text: ");
 	const cost = game.lodash.parseInt(await input("Cost: "));
-	const classes = game.lodash.startCase(await input("Classes: ")) as Class;
+	const classes = await input("Classes: ");
 	const rarity = game.lodash.startCase(await input("Rarity: ")) as Rarity;
 	const keywords = await input("Keywords: ");
 
-	player1.heroClass = classes;
-
-	let runes = "";
-	if (player1.canUseRunes()) {
-		runes = await input("Runes: ");
+	let realClasses: Class[] = [];
+	if (classes) {
+		realClasses = classes
+			.split(", ")
+			.map((k) => game.lodash.startCase(k) as Class);
 	}
 
 	let realKeywords: Keyword[] | undefined;
@@ -111,12 +116,22 @@ async function common(): Promise<BlueprintWithOptional> {
 			.map((k) => game.lodash.startCase(k) as Keyword);
 	}
 
+	let runes = "";
+	for (const c of realClasses) {
+		player1.heroClass = c;
+
+		if (player1.canUseRunes()) {
+			runes = await input("Runes: ");
+			break;
+		}
+	}
+
 	return {
 		name,
 		text,
 		cost,
 		type,
-		classes: [classes],
+		classes: realClasses,
 		rarity,
 		runes,
 		keywords: realKeywords,

--- a/tools/cardcreator/custom.ts
+++ b/tools/cardcreator/custom.ts
@@ -225,7 +225,7 @@ const cardTypeFunctions: {
  */
 export async function main(
 	debug = false,
-	overrideType?: lib.CcType,
+	overrideType?: lib.CCType,
 ): Promise<string | false> {
 	// Reset the shouldExit switch so that the program doesn't immediately exit when the user enters the ccc, exits, then enters ccc again
 	shouldExit = false;
@@ -262,7 +262,7 @@ export async function main(
 	// Actually create the card
 	console.log("Creating file...");
 
-	let cctype: lib.CcType = "Custom";
+	let cctype: lib.CCType = lib.CCType.Custom;
 	if (overrideType) {
 		cctype = overrideType;
 	}

--- a/tools/cardcreator/custom.ts
+++ b/tools/cardcreator/custom.ts
@@ -188,17 +188,24 @@ const cardTypeFunctions: {
 	async Hero(): Promise<Blueprint> {
 		const card = await common();
 
-		const armor = game.lodash.parseInt(await input("Armor (Default: 5):")) ?? 5;
+		const armor =
+			game.lodash.parseInt(await input("Armor (Default: 5): ")) ?? 5;
+		const heropowerId =
+			game.lodash.parseInt(
+				await input("Hero Power ID (Leave blank to create a new one): "),
+			) ?? 0;
 
-		console.log("\n<green bold>Make the Hero Power:<green bold>\n");
-		if (!(await main())) {
-			throw new Error("Failed to create hero power");
+		if (heropowerId === 0) {
+			console.log("\n<green bold>Make the Hero Power:<green bold>\n");
+			if (!(await main())) {
+				throw new Error("Failed to create hero power");
+			}
 		}
 
 		return applyCard({
 			...card,
 			armor,
-			heropowerId: lib.getLatestId(),
+			heropowerId: heropowerId || lib.getLatestId(),
 		});
 	},
 
@@ -252,6 +259,10 @@ export async function main(
 	type = game.lodash.startCase(await input("Type: ")) as Type;
 	if (shouldExit) {
 		return false;
+	}
+
+	if (type === ("Heropower" as Type) || type === ("Hero Power" as Type)) {
+		type = Type.HeroPower;
 	}
 
 	if (!Object.keys(cardTypeFunctions).includes(type)) {

--- a/tools/cardcreator/lib.ts
+++ b/tools/cardcreator/lib.ts
@@ -7,7 +7,12 @@ const { game } = createGame();
 // If this is set to true, this will force debug mode.
 const mainDebugSwitch = false;
 
-export type CcType = "Unknown" | "Class" | "Custom" | "Vanilla";
+export enum CCType {
+	Unknown = "Unknown",
+	Class = "Class",
+	Custom = "Custom",
+	Vanilla = "Vanilla",
+}
 
 /**
  * Returns the ability of a card based on its type.
@@ -137,7 +142,7 @@ export function getLatestId(): number {
  * @returns The path of the created file.
  */
 export async function create(
-	creatorType: CcType,
+	creatorType: CCType,
 	blueprint: BlueprintWithOptional,
 	overridePath?: string,
 	overrideFilename?: string,

--- a/tools/cardcreator/lib.ts
+++ b/tools/cardcreator/lib.ts
@@ -1,5 +1,5 @@
 import { createGame } from "@Core/game.js";
-import type { BlueprintWithOptional, CardType } from "@Game/types.js";
+import { type BlueprintWithOptional, Type } from "@Game/types.js";
 import { resumeTagParsing, stopTagParsing } from "chalk-tags";
 
 const { game } = createGame();
@@ -21,28 +21,28 @@ function getCardAbility(blueprint: BlueprintWithOptional): string {
 
 	// If the card is a spell, the ability is 'cast'
 	switch (blueprint.type) {
-		case "Spell": {
+		case Type.Spell: {
 			ability = "Cast";
 			break;
 		}
 
-		case "Hero": {
+		case Type.Hero: {
 			ability = "Battlecry";
 			break;
 		}
 
-		case "Location": {
+		case Type.Location: {
 			ability = "Use";
 			break;
 		}
 
-		case "Heropower": {
+		case Type.HeroPower: {
 			ability = "Heropower";
 			break;
 		}
 
-		case "Minion":
-		case "Weapon": {
+		case Type.Minion:
+		case Type.Weapon: {
 			// Try to extract an ability from the card's description
 			const reg = /([A-Z][a-z].*?):/g;
 			const foundAbility = reg.exec(blueprint.text);
@@ -61,7 +61,7 @@ function getCardAbility(blueprint: BlueprintWithOptional): string {
 			break;
 		}
 
-		case "Undefined": {
+		case Type.Undefined: {
 			throw new Error("undefined type");
 		}
 
@@ -90,11 +90,11 @@ function generateCardPath(blueprint: BlueprintWithOptional): string {
 
 	// If the card has the word "Secret" in its description, put it in the ".../Secrets/..." folder.
 	if (blueprint.text.includes("Secret:")) {
-		type = "Secret" as CardType;
+		type = "Secret" as Type;
 	}
 
 	// If the type is Hero, we want the card to go to '.../Heroes/...' and not to '.../Heros/...'
-	const typeString = type === "Hero" ? "Heroe" : type;
+	const typeString = type === Type.Hero ? "Heroe" : type;
 
 	const collectibleString = blueprint.collectible
 		? "Collectible"
@@ -149,7 +149,7 @@ export async function create(
 	 */
 
 	// Validate
-	if (blueprint.type !== "Heropower") {
+	if (blueprint.type !== Type.HeroPower) {
 		const error = game.functions.card.validateBlueprint(blueprint);
 		if (error !== true) {
 			console.error(error);

--- a/tools/cardcreator/vanilla.ts
+++ b/tools/cardcreator/vanilla.ts
@@ -1,12 +1,12 @@
 import { createGame } from "@Core/game.js";
-import type {
-	Blueprint,
-	CardClass,
-	CardRarity,
-	CardType,
-	MinionTribe,
+import {
+	type Blueprint,
+	Class,
+	type MinionTribe,
+	Rarity,
 	SpellSchool,
-	VanillaCard,
+	Type,
+	type VanillaCard,
 } from "@Game/types.js";
 import * as lib from "./lib.js";
 
@@ -24,15 +24,13 @@ export async function create(
 	overrideType?: lib.CcType,
 ): Promise<void> {
 	// Harvest info
-	let cardClass = game.lodash.capitalize(
-		card.cardClass ?? "Neutral",
-	) as CardClass;
+	let cardClass = game.lodash.capitalize(card.cardClass ?? "Neutral") as Class;
 	const collectible = card.collectible ?? false;
 	const cost = card.cost ?? 0;
 	const { name } = card;
-	let rarity: CardRarity = "Free";
+	let rarity = Rarity.Free;
 	if (card.rarity) {
-		rarity = game.lodash.capitalize(card.rarity) as CardRarity;
+		rarity = game.lodash.capitalize(card.rarity) as Rarity;
 	}
 
 	let text = card.text ?? "";
@@ -41,7 +39,7 @@ export async function create(
 		typeString = "Heropower" as typeof typeString;
 	}
 
-	const type = typeString as CardType;
+	const type = typeString as Type;
 
 	// Minion info
 	const attack = card.attack ?? -1;
@@ -52,7 +50,7 @@ export async function create(
 	}
 
 	// Spell info
-	let spellSchool: SpellSchool = "None";
+	let spellSchool = SpellSchool.None;
 	if (card.spellSchool) {
 		spellSchool = game.lodash.capitalize(card.spellSchool) as SpellSchool;
 	}
@@ -64,18 +62,18 @@ export async function create(
 	text = text.replaceAll("\n", " ");
 	text = text.replaceAll("[x]", "");
 
-	const classes = (await game.functions.card.getClasses()) as CardClass[];
-	classes.push("Neutral");
+	const classes = (await game.functions.card.getClasses()) as Class[];
+	classes.push(Class.Neutral);
 
 	while (!classes.includes(cardClass)) {
 		cardClass = game.lodash.startCase(
 			await game.input(
 				"<red>Was not able to find the class of this card.\nWhat is the class of this card? </red>",
 			),
-		) as CardClass;
+		) as Class;
 	}
 
-	if (type === "Hero") {
+	if (type === Type.Hero) {
 		// Add the hero power
 		console.log("<green>Adding the hero power</green>");
 
@@ -103,7 +101,7 @@ export async function create(
 	};
 
 	switch (type) {
-		case "Minion": {
+		case Type.Minion: {
 			blueprint = Object.assign(blueprint, {
 				attack,
 				health,
@@ -114,7 +112,7 @@ export async function create(
 			break;
 		}
 
-		case "Spell": {
+		case Type.Spell: {
 			blueprint = Object.assign(blueprint, {
 				spellSchool,
 			});
@@ -122,7 +120,7 @@ export async function create(
 			break;
 		}
 
-		case "Weapon": {
+		case Type.Weapon: {
 			blueprint = Object.assign(blueprint, {
 				attack,
 				health: durability,
@@ -131,7 +129,7 @@ export async function create(
 			break;
 		}
 
-		case "Hero": {
+		case Type.Hero: {
 			blueprint = Object.assign(blueprint, {
 				armor: card.armor,
 				heropowerId: lib.getLatestId(),
@@ -140,7 +138,7 @@ export async function create(
 			break;
 		}
 
-		case "Location": {
+		case Type.Location: {
 			blueprint = Object.assign(blueprint, {
 				durability: health,
 				cooldown: 2,
@@ -149,8 +147,8 @@ export async function create(
 			break;
 		}
 
-		case "Heropower":
-		case "Undefined": {
+		case Type.HeroPower:
+		case Type.Undefined: {
 			break;
 		}
 

--- a/tools/cardcreator/vanilla.ts
+++ b/tools/cardcreator/vanilla.ts
@@ -178,9 +178,7 @@ export async function main(
 
 	let running = true;
 	while (running) {
-		const cardName = await game.input(
-			"\nName / dbfId (Type 'back' to cancel): ",
-		);
+		const cardName = await game.input("Name / dbfId (Type 'back' to cancel): ");
 		if (game.functions.interact.isInputExit(cardName)) {
 			running = false;
 			break;

--- a/tools/cardcreator/vanilla.ts
+++ b/tools/cardcreator/vanilla.ts
@@ -21,7 +21,7 @@ const { game } = createGame();
 export async function create(
 	card: VanillaCard,
 	debug: boolean,
-	overrideType?: lib.CcType,
+	overrideType?: lib.CCType,
 ): Promise<void> {
 	// Harvest info
 	let cardClass = game.lodash.capitalize(card.cardClass ?? "Neutral") as Class;
@@ -155,7 +155,7 @@ export async function create(
 		// No default
 	}
 
-	let cctype: lib.CcType = "Vanilla";
+	let cctype: lib.CCType = lib.CCType.Vanilla;
 	if (overrideType) {
 		cctype = overrideType;
 	}
@@ -170,7 +170,7 @@ export async function create(
  */
 export async function main(
 	debug = false,
-	overrideType?: lib.CcType,
+	overrideType?: lib.CCType,
 ): Promise<boolean> {
 	console.log("Hearthstone.js Vanilla Card Creator (C) 2022\n");
 

--- a/tools/deckcreator.ts
+++ b/tools/deckcreator.ts
@@ -436,9 +436,9 @@ async function showCards(): Promise<void> {
 	const oldSortType = settings.sort.type;
 	const oldSortOrder = settings.sort.order;
 	console.log(
-		"Sorting by %s, %sending.",
+		"Sorting by %s, %s.",
 		settings.sort.type.toUpperCase(),
-		settings.sort.order,
+		settings.sort.order.toLowerCase(),
 	);
 
 	// Sort
@@ -457,17 +457,17 @@ async function showCards(): Promise<void> {
 
 	if (sortOrderInvalid) {
 		console.log(
-			"<yellow>Ordering by </yellow>'%sending'<yellow> failed! Falling back to </yellow>%sending.",
+			"<yellow>Ordering by </yellow>'%sending'<yellow> failed! Falling back to </yellow>%s.",
 			oldSortOrder,
-			settings.sort.order,
+			settings.sort.order.toLowerCase(),
 		);
 	}
 
 	if (sortTypeInvalid || sortOrderInvalid) {
 		console.log(
-			"\nSorting by %s, %sending.",
+			"\nSorting by %s, %s.",
 			settings.sort.type.toUpperCase(),
-			settings.sort.order,
+			settings.sort.order.toLowerCase(),
 		);
 	}
 


### PR DESCRIPTION
Closes #378

I like to put what I'm working on out there instead of keeping it on my computer, especially since I'm working on different computers often.

~~The cards have not been touched yet, and there are still 49 errors outside the cards, and some logic might have broken.~~

- [x] Find more union types and destroy them:
    - [x] `interact.prompt.useLocation`
    - [x] `Player.addQuest`
- [x] Make `EventListenerMessage` enum the return value of the quest callback.
- [x] Make the card creators work:
    - [x] Lib:
        - [x] Minion
        - [x] Spell
        - [x] Weapon
        - [x] Location
        - [x] Hero
        - [x] Heropower
    - [x] Custom:
        - [x] Minion
        - [x] Spell
        - [x] Weapon
        - [x] Location
        - [x] Hero
        - [x] Heropower
    - [x] Vanilla:
        - [x] Minion
        - [x] Spell
        - [x] Weapon
        - [x] Location
        - [x] Hero
        - [x] Heropower
    - [x] Class  
- [x] Make sure the deck creator works.
- [x] Make sure the scripts work.
- [x] Make sure the game works.