### PR TITLE
Add tags to replace cardCollections

### DIFF
--- a/cards/1-sheep.ts
+++ b/cards/1-sheep.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 1,
 
 	attack: 1,

--- a/cards/2-the-coin.ts
+++ b/cards/2-the-coin.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 2,
 
 	spellSchool: "None",

--- a/cards/3-plant.ts
+++ b/cards/3-plant.ts
@@ -13,6 +13,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 3,
 
 	attack: 1,

--- a/cards/85-jade-golem.ts
+++ b/cards/85-jade-golem.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 85,
 
 	attack: 1,

--- a/cards/Classes/Druid/Collectible/Heroes/5-Cost/89-wildheart-guff.ts
+++ b/cards/Classes/Druid/Collectible/Heroes/5-Cost/89-wildheart-guff.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 89,
 
 	armor: 5,

--- a/cards/Classes/Druid/Collectible/Spells/0-Cost/93-aquatic-form.ts
+++ b/cards/Classes/Druid/Collectible/Spells/0-Cost/93-aquatic-form.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Rare",
 	collectible: true,
+	tags: [],
 	id: 93,
 
 	spellSchool: "None",

--- a/cards/Classes/Druid/Collectible/Spells/1-Cost/101-floops-glorious-gloop.ts
+++ b/cards/Classes/Druid/Collectible/Spells/1-Cost/101-floops-glorious-gloop.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 101,
 
 	spellSchool: "Nature",

--- a/cards/Classes/Druid/Collectible/Spells/1-Cost/84-jade-idol.ts
+++ b/cards/Classes/Druid/Collectible/Spells/1-Cost/84-jade-idol.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Rare",
 	collectible: true,
+	tags: [],
 	id: 84,
 
 	spellSchool: "None",

--- a/cards/Classes/Druid/Collectible/Spells/2-Cost/90-moonlit-guidance.ts
+++ b/cards/Classes/Druid/Collectible/Spells/2-Cost/90-moonlit-guidance.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Rare",
 	collectible: true,
+	tags: [],
 	id: 90,
 
 	spellSchool: "Arcane",

--- a/cards/Classes/Druid/Collectible/Spells/2-Cost/91-dew-process.ts
+++ b/cards/Classes/Druid/Collectible/Spells/2-Cost/91-dew-process.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Rare",
 	collectible: true,
+	tags: [],
 	id: 91,
 
 	spellSchool: "Nature",

--- a/cards/Classes/Druid/Collectible/Spells/2-Cost/92-invigorate.ts
+++ b/cards/Classes/Druid/Collectible/Spells/2-Cost/92-invigorate.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Rare",
 	collectible: true,
+	tags: [],
 	id: 92,
 
 	spellSchool: "Nature",

--- a/cards/Classes/Druid/Collectible/Spells/3-Cost/94-frost-lotus-seedling.ts
+++ b/cards/Classes/Druid/Collectible/Spells/3-Cost/94-frost-lotus-seedling.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Rare",
 	collectible: true,
+	tags: [],
 	id: 94,
 
 	spellSchool: "Nature",

--- a/cards/Classes/Druid/Collectible/Spells/4-Cost/82-poison-seeds.ts
+++ b/cards/Classes/Druid/Collectible/Spells/4-Cost/82-poison-seeds.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Common",
 	collectible: true,
+	tags: [],
 	id: 82,
 
 	spellSchool: "Nature",

--- a/cards/Classes/Druid/Collectible/Spells/4-Cost/86-branching-paths.ts
+++ b/cards/Classes/Druid/Collectible/Spells/4-Cost/86-branching-paths.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Epic",
 	collectible: true,
+	tags: [],
 	id: 86,
 
 	spellSchool: "None",

--- a/cards/Classes/Druid/Collectible/Spells/4-Cost/87-oaken-summons.ts
+++ b/cards/Classes/Druid/Collectible/Spells/4-Cost/87-oaken-summons.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Common",
 	collectible: true,
+	tags: [],
 	id: 87,
 
 	spellSchool: "Nature",

--- a/cards/Classes/Druid/Collectible/Spells/5-Cost/97-flipper-friends.ts
+++ b/cards/Classes/Druid/Collectible/Spells/5-Cost/97-flipper-friends.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Common",
 	collectible: true,
+	tags: [],
 	id: 97,
 
 	spellSchool: "Nature",

--- a/cards/Classes/Druid/Collectible/Spells/7-Cost/100-scale-of-onyxia.ts
+++ b/cards/Classes/Druid/Collectible/Spells/7-Cost/100-scale-of-onyxia.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Common",
 	collectible: true,
+	tags: [],
 	id: 100,
 
 	spellSchool: "None",

--- a/cards/Classes/Druid/Uncollectible/Heropowers/2-Cost/113-nurture.ts
+++ b/cards/Classes/Druid/Uncollectible/Heropowers/2-Cost/113-nurture.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 113,
 
 	async heropower(owner, self) {

--- a/cards/Classes/Druid/Uncollectible/Minions/1-Cost/83-treant.ts
+++ b/cards/Classes/Druid/Uncollectible/Minions/1-Cost/83-treant.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 83,
 
 	attack: 2,

--- a/cards/Classes/Druid/Uncollectible/Minions/1-Cost/95-otter.ts
+++ b/cards/Classes/Druid/Uncollectible/Minions/1-Cost/95-otter.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 95,
 
 	attack: 1,

--- a/cards/Classes/Druid/Uncollectible/Minions/6-Cost/96-orca.ts
+++ b/cards/Classes/Druid/Uncollectible/Minions/6-Cost/96-orca.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 96,
 
 	attack: 6,

--- a/cards/Classes/Mage/Collectible/Spells/10-Cost/105-pyroblast.ts
+++ b/cards/Classes/Mage/Collectible/Spells/10-Cost/105-pyroblast.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Mage"],
 	rarity: "Epic",
 	collectible: true,
+	tags: [],
 	id: 105,
 
 	spellSchool: "Fire",

--- a/cards/Classes/Neutral/Collectible/Locations/7-Cost/102-prison-of-yogg-saron.ts
+++ b/cards/Classes/Neutral/Collectible/Locations/7-Cost/102-prison-of-yogg-saron.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 102,
 
 	durability: 3,

--- a/cards/Classes/Neutral/Collectible/Minions/1-Cost/110-chaotic-tendril.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/1-Cost/110-chaotic-tendril.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Common",
 	collectible: true,
+	tags: [],
 	id: 110,
 
 	attack: 1,

--- a/cards/Classes/Neutral/Collectible/Minions/10-Cost/103-yogg-saron-hopes-end.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/10-Cost/103-yogg-saron-hopes-end.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 103,
 
 	attack: 7,

--- a/cards/Classes/Neutral/Collectible/Minions/10-Cost/104-yogg-saron-master-of-fate.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/10-Cost/104-yogg-saron-master-of-fate.ts
@@ -13,6 +13,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 104,
 
 	attack: 7,

--- a/cards/Classes/Neutral/Collectible/Minions/4-Cost/88-injured-marauder.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/4-Cost/88-injured-marauder.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Common",
 	collectible: true,
+	tags: [],
 	id: 88,
 
 	attack: 5,

--- a/cards/Classes/Neutral/Collectible/Minions/4-Cost/98-archmage-vargoth.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/4-Cost/98-archmage-vargoth.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 98,
 
 	attack: 2,

--- a/cards/Classes/Neutral/Collectible/Minions/9-Cost/106-yogg-saron-unleashed.ts
+++ b/cards/Classes/Neutral/Collectible/Minions/9-Cost/106-yogg-saron-unleashed.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 106,
 
 	attack: 7,

--- a/cards/Classes/Neutral/Uncollectible/Minions/1-Cost/99-onyxian-whelp.ts
+++ b/cards/Classes/Neutral/Uncollectible/Minions/1-Cost/99-onyxian-whelp.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 99,
 
 	attack: 2,

--- a/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/107-induce-insanity.ts
+++ b/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/107-induce-insanity.ts
@@ -13,6 +13,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 107,
 
 	spellSchool: "None",

--- a/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/108-reign-of-chaos.ts
+++ b/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/108-reign-of-chaos.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 108,
 
 	spellSchool: "None",

--- a/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/109-tentacle-swarm.ts
+++ b/cards/Classes/Neutral/Uncollectible/Spells/0-Cost/109-tentacle-swarm.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 109,
 
 	spellSchool: "None",

--- a/cards/Debug/65-10-mana.ts
+++ b/cards/Debug/65-10-mana.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 65,
 
 	spellSchool: "None",

--- a/cards/Debug/66-inf-mana.ts
+++ b/cards/Debug/66-inf-mana.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 66,
 
 	spellSchool: "None",

--- a/cards/Examples/1/1-minion.ts
+++ b/cards/Examples/1/1-minion.ts
@@ -35,6 +35,15 @@ export const blueprint: Blueprint = {
 	 */
 	collectible: false,
 
+	/**
+	 * Any tags that should be applied to the card.
+	 * Tags are used to group cards together. They should be lowercase.
+	 * E.g. "lackey"
+	 *
+	 * This can be queried like this: `Card.allWithTags(["lackey"]);`
+	 */
+	tags: [],
+
 	/*
 	 * The ID of the card. This is used in deckcodes, and should be unique per blueprint. This gets generated automatically by the card creator.
 	 * If you have debug mode enabled, you can type `/give (id)` to give yourself the card with that id.

--- a/cards/Examples/1/2-spell.ts
+++ b/cards/Examples/1/2-spell.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 30,
 
 	// The school of the spell.

--- a/cards/Examples/1/3-weapon.ts
+++ b/cards/Examples/1/3-weapon.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 31,
 
 	// Weapons have attack / health, but no tribe

--- a/cards/Examples/1/4-taunt.ts
+++ b/cards/Examples/1/4-taunt.ts
@@ -19,6 +19,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 32,
 
 	attack: 2,

--- a/cards/Examples/1/5-battlecry.ts
+++ b/cards/Examples/1/5-battlecry.ts
@@ -17,6 +17,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 33,
 
 	attack: 1,

--- a/cards/Examples/1/6-dredge.ts
+++ b/cards/Examples/1/6-dredge.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 34,
 
 	attack: 1,

--- a/cards/Examples/1/7-another-ability.ts
+++ b/cards/Examples/1/7-another-ability.ts
@@ -27,6 +27,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 77,
 
 	attack: 1,

--- a/cards/Examples/1/last-combined.ts
+++ b/cards/Examples/1/last-combined.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Priest", "Paladin"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 35,
 
 	attack: 4,

--- a/cards/Examples/2/1-location.ts
+++ b/cards/Examples/2/1-location.ts
@@ -13,6 +13,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 36,
 
 	// This is the amount of times you can trigger the location card before it breaking.

--- a/cards/Examples/2/2-Hero/2-hero.ts
+++ b/cards/Examples/2/2-Hero/2-hero.ts
@@ -13,6 +13,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 37,
 
 	// The amount of armor that the player will gain when playing this card.

--- a/cards/Examples/2/2-Hero/2-heropower.ts
+++ b/cards/Examples/2/2-Hero/2-heropower.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 130,
 
 	// This gets triggered when the player uses their hero power.

--- a/cards/Examples/2/3-dormant.ts
+++ b/cards/Examples/2/3-dormant.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 38,
 
 	attack: 8,

--- a/cards/Examples/2/4-runes.ts
+++ b/cards/Examples/2/4-runes.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 39,
 
 	attack: 1,

--- a/cards/Examples/2/5-corrupt.ts
+++ b/cards/Examples/2/5-corrupt.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 40,
 
 	attack: 1,

--- a/cards/Examples/2/5-corrupted.ts
+++ b/cards/Examples/2/5-corrupted.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 41,
 
 	attack: 2,

--- a/cards/Examples/2/6-forge.ts
+++ b/cards/Examples/2/6-forge.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 75,
 
 	attack: 1,

--- a/cards/Examples/2/6-forged.ts
+++ b/cards/Examples/2/6-forged.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 76,
 
 	attack: 2,

--- a/cards/Examples/2/7-Titan/7-ability1.ts
+++ b/cards/Examples/2/7-Titan/7-ability1.ts
@@ -13,6 +13,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 79,
 
 	spellSchool: "None",

--- a/cards/Examples/2/7-Titan/7-ability2.ts
+++ b/cards/Examples/2/7-Titan/7-ability2.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 80,
 
 	spellSchool: "None",

--- a/cards/Examples/2/7-Titan/7-ability3.ts
+++ b/cards/Examples/2/7-Titan/7-ability3.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 81,
 
 	spellSchool: "None",

--- a/cards/Examples/2/7-Titan/7-titan.ts
+++ b/cards/Examples/2/7-Titan/7-titan.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 78,
 
 	attack: 10,

--- a/cards/Examples/2/8-spelldamage.ts
+++ b/cards/Examples/2/8-spelldamage.ts
@@ -19,6 +19,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 42,
 
 	spellSchool: "None",

--- a/cards/Examples/2/9-Colossal/left.ts
+++ b/cards/Examples/2/9-Colossal/left.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 43,
 
 	attack: 2,

--- a/cards/Examples/2/9-Colossal/main.ts
+++ b/cards/Examples/2/9-Colossal/main.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 45,
 
 	attack: 5,

--- a/cards/Examples/2/9-Colossal/right.ts
+++ b/cards/Examples/2/9-Colossal/right.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 44,
 
 	attack: 1,

--- a/cards/Examples/2/last-Combined/left.ts
+++ b/cards/Examples/2/last-Combined/left.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 46,
 
 	attack: 3,

--- a/cards/Examples/2/last-Combined/main-corrupted.ts
+++ b/cards/Examples/2/last-Combined/main-corrupted.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 49,
 
 	attack: 9,

--- a/cards/Examples/2/last-Combined/main.ts
+++ b/cards/Examples/2/last-Combined/main.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 48,
 
 	attack: 5,

--- a/cards/Examples/2/last-Combined/right.ts
+++ b/cards/Examples/2/last-Combined/right.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 47,
 
 	attack: 1,

--- a/cards/Examples/3/1-manathirst.ts
+++ b/cards/Examples/3/1-manathirst.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 50,
 
 	attack: 1,

--- a/cards/Examples/3/2-discover.ts
+++ b/cards/Examples/3/2-discover.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 51,
 
 	spellSchool: "None",

--- a/cards/Examples/3/3-condition.ts
+++ b/cards/Examples/3/3-condition.ts
@@ -15,6 +15,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 52,
 
 	attack: 5,

--- a/cards/Examples/3/4-placeholder.ts
+++ b/cards/Examples/3/4-placeholder.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 53,
 
 	spellSchool: "None",

--- a/cards/Examples/3/last-combined.ts
+++ b/cards/Examples/3/last-combined.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 54,
 
 	spellSchool: "None",

--- a/cards/Examples/4/1-passive.ts
+++ b/cards/Examples/4/1-passive.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 55,
 
 	attack: 1,

--- a/cards/Examples/4/2-enchantments.ts
+++ b/cards/Examples/4/2-enchantments.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 56,
 
 	attack: 1,

--- a/cards/Examples/4/3-event-listener.ts
+++ b/cards/Examples/4/3-event-listener.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 57,
 
 	attack: 1,

--- a/cards/Examples/4/4-quest.ts
+++ b/cards/Examples/4/4-quest.ts
@@ -14,6 +14,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 58,
 
 	spellSchool: "None",

--- a/cards/Examples/4/5-tick-hooks.ts
+++ b/cards/Examples/4/5-tick-hooks.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 59,
 
 	attack: 1,

--- a/cards/Examples/4/last-combined.ts
+++ b/cards/Examples/4/last-combined.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 60,
 
 	spellSchool: "None",

--- a/cards/Examples/DIY/1.ts
+++ b/cards/Examples/DIY/1.ts
@@ -10,7 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
-	tags: [],
+	tags: ["diy"],
 	id: 61,
 
 	attack: 0,

--- a/cards/Examples/DIY/1.ts
+++ b/cards/Examples/DIY/1.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 61,
 
 	attack: 0,

--- a/cards/Examples/DIY/2.ts
+++ b/cards/Examples/DIY/2.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 62,
 
 	spellSchool: "None",

--- a/cards/Examples/DIY/2.ts
+++ b/cards/Examples/DIY/2.ts
@@ -10,7 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
-	tags: [],
+	tags: ["diy"],
 	id: 62,
 
 	spellSchool: "None",

--- a/cards/Examples/DIY/3.ts
+++ b/cards/Examples/DIY/3.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 63,
 
 	spellSchool: "None",

--- a/cards/Examples/DIY/3.ts
+++ b/cards/Examples/DIY/3.ts
@@ -11,7 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
-	tags: [],
+	tags: ["diy"],
 	id: 63,
 
 	spellSchool: "None",

--- a/cards/Examples/DIY/4.ts
+++ b/cards/Examples/DIY/4.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 64,
 
 	attack: 0,

--- a/cards/Examples/DIY/4.ts
+++ b/cards/Examples/DIY/4.ts
@@ -10,7 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
-	tags: [],
+	tags: ["diy"],
 	id: 64,
 
 	attack: 0,

--- a/cards/Examples/Test/cant-attack.ts
+++ b/cards/Examples/Test/cant-attack.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 134,
 
 	attack: 1,

--- a/cards/Examples/Test/deathrattle.ts
+++ b/cards/Examples/Test/deathrattle.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 72,
 
 	attack: 1,

--- a/cards/Examples/Test/disable-heropower.ts
+++ b/cards/Examples/Test/disable-heropower.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 136,
 
 	attack: 1,

--- a/cards/Examples/Test/divine-shield.ts
+++ b/cards/Examples/Test/divine-shield.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 73,
 
 	attack: 1,

--- a/cards/Examples/Test/force-attack.ts
+++ b/cards/Examples/Test/force-attack.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 137,
 
 	attack: 1,

--- a/cards/Examples/Test/forgetful.ts
+++ b/cards/Examples/Test/forgetful.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 138,
 
 	attack: 5,

--- a/cards/Examples/Test/frozen.ts
+++ b/cards/Examples/Test/frozen.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 74,
 
 	attack: 1,

--- a/cards/Examples/Test/immortal.ts
+++ b/cards/Examples/Test/immortal.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 135,
 
 	attack: 1,

--- a/cards/Examples/Test/joust.ts
+++ b/cards/Examples/Test/joust.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 139,
 
 	attack: 1,

--- a/cards/Examples/Test/summon-on-draw.ts
+++ b/cards/Examples/Test/summon-on-draw.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 133,
 
 	attack: 1,

--- a/cards/Examples/Test/unbreakable.ts
+++ b/cards/Examples/Test/unbreakable.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 140,
 
 	attack: 2,

--- a/cards/Examples/Test/unlimited-attacks.ts
+++ b/cards/Examples/Test/unlimited-attacks.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 141,
 
 	attack: 1,

--- a/cards/Examples/Unordered/Card References/131-simple.ts
+++ b/cards/Examples/Unordered/Card References/131-simple.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 131,
 
 	attack: 1,

--- a/cards/Examples/Unordered/Card References/132-circular.ts
+++ b/cards/Examples/Unordered/Card References/132-circular.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 132,
 
 	attack: 1,

--- a/cards/Galakrond/111-dragon-claw.ts
+++ b/cards/Galakrond/111-dragon-claw.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 111,
 
 	attack: 5,

--- a/cards/Galakrond/112-brewing-storm.ts
+++ b/cards/Galakrond/112-brewing-storm.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 112,
 
 	attack: 2,

--- a/cards/Galakrond/Priest/128-heropower.ts
+++ b/cards/Galakrond/Priest/128-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Priest"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 128,
 
 	async heropower(owner, self) {

--- a/cards/Galakrond/Priest/70-hero.ts
+++ b/cards/Galakrond/Priest/70-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Priest"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 70,
 
 	armor: 5,

--- a/cards/Galakrond/Priest/70-hero.ts
+++ b/cards/Galakrond/Priest/70-hero.ts
@@ -10,7 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Priest"],
 	rarity: "Legendary",
 	collectible: true,
-	tags: [],
+	tags: ["galakrond"],
 	id: 70,
 
 	armor: 5,

--- a/cards/Galakrond/Rogue/125-heropower.ts
+++ b/cards/Galakrond/Rogue/125-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Rogue"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 125,
 
 	async heropower(owner, self) {

--- a/cards/Galakrond/Rogue/125-heropower.ts
+++ b/cards/Galakrond/Rogue/125-heropower.ts
@@ -16,12 +16,12 @@ export const blueprint: Blueprint = {
 
 	async heropower(owner, self) {
 		// Add a lacky to your hand.
-		const lackeyId = game.lodash.sample(game.cardCollections.lackeys);
+		const lackeyId = game.lodash.sample(await Card.allWithTags(["lackey"]));
 		if (!lackeyId) {
 			return;
 		}
 
-		const lackey = await Card.create(lackeyId, owner);
+		const lackey = await Card.create(lackeyId.id, owner);
 
 		await owner.addToHand(lackey);
 	},

--- a/cards/Galakrond/Rogue/125-heropower.ts
+++ b/cards/Galakrond/Rogue/125-heropower.ts
@@ -17,14 +17,12 @@ export const blueprint: Blueprint = {
 
 	async heropower(owner, self) {
 		// Add a lacky to your hand.
-		const lackeyId = game.lodash.sample(await Card.allWithTags(["lackey"]));
-		if (!lackeyId) {
+		const lackey = game.lodash.sample(await Card.allWithTags(["lackey"]));
+		if (!lackey) {
 			return;
 		}
 
-		const lackey = await Card.create(lackeyId.id, owner);
-
-		await owner.addToHand(lackey);
+		await owner.addToHand(await lackey.imperfectCopy());
 	},
 
 	async test(owner, self) {

--- a/cards/Galakrond/Rogue/67-hero.ts
+++ b/cards/Galakrond/Rogue/67-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Rogue"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 67,
 
 	armor: 5,

--- a/cards/Galakrond/Rogue/67-hero.ts
+++ b/cards/Galakrond/Rogue/67-hero.ts
@@ -10,7 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Rogue"],
 	rarity: "Legendary",
 	collectible: true,
-	tags: [],
+	tags: ["galakrond"],
 	id: 67,
 
 	armor: 5,

--- a/cards/Galakrond/Shaman/126-heropower.ts
+++ b/cards/Galakrond/Shaman/126-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 126,
 
 	async heropower(owner, self) {

--- a/cards/Galakrond/Shaman/68-hero.ts
+++ b/cards/Galakrond/Shaman/68-hero.ts
@@ -11,7 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Legendary",
 	collectible: true,
-	tags: [],
+	tags: ["galakrond"],
 	id: 68,
 
 	armor: 5,

--- a/cards/Galakrond/Shaman/68-hero.ts
+++ b/cards/Galakrond/Shaman/68-hero.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 68,
 
 	armor: 5,

--- a/cards/Galakrond/Warlock/129-heropower.ts
+++ b/cards/Galakrond/Warlock/129-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warlock"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 129,
 
 	async heropower(owner, self) {

--- a/cards/Galakrond/Warlock/71-hero.ts
+++ b/cards/Galakrond/Warlock/71-hero.ts
@@ -11,7 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warlock"],
 	rarity: "Legendary",
 	collectible: true,
-	tags: [],
+	tags: ["galakrond"],
 	id: 71,
 
 	armor: 5,

--- a/cards/Galakrond/Warlock/71-hero.ts
+++ b/cards/Galakrond/Warlock/71-hero.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warlock"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 71,
 
 	armor: 5,

--- a/cards/Galakrond/Warrior/127-heropower.ts
+++ b/cards/Galakrond/Warrior/127-heropower.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warrior"],
 	rarity: "Legendary",
 	collectible: false,
+	tags: [],
 	id: 127,
 
 	async heropower(owner, self) {

--- a/cards/Galakrond/Warrior/69-hero.ts
+++ b/cards/Galakrond/Warrior/69-hero.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warrior"],
 	rarity: "Legendary",
 	collectible: true,
+	tags: [],
 	id: 69,
 
 	armor: 5,

--- a/cards/Galakrond/Warrior/69-hero.ts
+++ b/cards/Galakrond/Warrior/69-hero.ts
@@ -1,6 +1,5 @@
 // Created by the Custom Card Creator
 
-import { Card } from "@Core/card.js";
 import type { Blueprint } from "@Game/types.js";
 
 export const blueprint: Blueprint = {
@@ -11,7 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warrior"],
 	rarity: "Legendary",
 	collectible: true,
-	tags: [],
+	tags: ["galakrond"],
 	id: 69,
 
 	armor: 5,

--- a/cards/Lackeys/24-ethereal.ts
+++ b/cards/Lackeys/24-ethereal.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["lackey"],
 	id: 24,
 
 	attack: 1,

--- a/cards/Lackeys/25-faceless.ts
+++ b/cards/Lackeys/25-faceless.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["lackey"],
 	id: 25,
 
 	attack: 1,

--- a/cards/Lackeys/26-goblin.ts
+++ b/cards/Lackeys/26-goblin.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["lackey"],
 	id: 26,
 
 	attack: 1,

--- a/cards/Lackeys/27-kobold.ts
+++ b/cards/Lackeys/27-kobold.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["lackey"],
 	id: 27,
 
 	attack: 1,

--- a/cards/Lackeys/28-witchy.ts
+++ b/cards/Lackeys/28-witchy.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Neutral"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["lackey"],
 	id: 28,
 
 	attack: 1,

--- a/cards/StartingHeroes/Death Knight/124-heropower.ts
+++ b/cards/StartingHeroes/Death Knight/124-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Death Knight"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 124,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Death Knight/14-hero.ts
+++ b/cards/StartingHeroes/Death Knight/14-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Death Knight"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 14,
 
 	armor: 0,

--- a/cards/StartingHeroes/Death Knight/23-frail-ghoul.ts
+++ b/cards/StartingHeroes/Death Knight/23-frail-ghoul.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Death Knight"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 23,
 
 	attack: 1,

--- a/cards/StartingHeroes/Demon Hunter/123-heropower.ts
+++ b/cards/StartingHeroes/Demon Hunter/123-heropower.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Demon Hunter"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 123,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Demon Hunter/13-hero.ts
+++ b/cards/StartingHeroes/Demon Hunter/13-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Demon Hunter"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 13,
 
 	armor: 0,

--- a/cards/StartingHeroes/Druid/115-heropower.ts
+++ b/cards/StartingHeroes/Druid/115-heropower.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 115,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Druid/5-hero.ts
+++ b/cards/StartingHeroes/Druid/5-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Druid"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 5,
 
 	armor: 0,

--- a/cards/StartingHeroes/Hunter/116-heropower.ts
+++ b/cards/StartingHeroes/Hunter/116-heropower.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Hunter"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 116,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Hunter/6-hero.ts
+++ b/cards/StartingHeroes/Hunter/6-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Hunter"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 6,
 
 	armor: 0,

--- a/cards/StartingHeroes/Mage/114-heropower.ts
+++ b/cards/StartingHeroes/Mage/114-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Mage"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 114,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Mage/4-hero.ts
+++ b/cards/StartingHeroes/Mage/4-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Mage"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 4,
 
 	armor: 0,

--- a/cards/StartingHeroes/Paladin/10-hero.ts
+++ b/cards/StartingHeroes/Paladin/10-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Paladin"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 10,
 
 	armor: 0,

--- a/cards/StartingHeroes/Paladin/120-heropower.ts
+++ b/cards/StartingHeroes/Paladin/120-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Paladin"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 120,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Paladin/20-silver-hand-recruit.ts
+++ b/cards/StartingHeroes/Paladin/20-silver-hand-recruit.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Paladin"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 20,
 
 	attack: 1,

--- a/cards/StartingHeroes/Priest/118-heropower.ts
+++ b/cards/StartingHeroes/Priest/118-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Priest"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 118,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Priest/8-hero.ts
+++ b/cards/StartingHeroes/Priest/8-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Priest"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 8,
 
 	armor: 0,

--- a/cards/StartingHeroes/Rogue/12-hero.ts
+++ b/cards/StartingHeroes/Rogue/12-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Rogue"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 12,
 
 	armor: 0,

--- a/cards/StartingHeroes/Rogue/122-heropower.ts
+++ b/cards/StartingHeroes/Rogue/122-heropower.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Rogue"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 122,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Rogue/22-wicked-knife.ts
+++ b/cards/StartingHeroes/Rogue/22-wicked-knife.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Rogue"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 22,
 
 	attack: 1,

--- a/cards/StartingHeroes/Shaman/19-windswept-elemental.ts
+++ b/cards/StartingHeroes/Shaman/19-windswept-elemental.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 19,
 
 	attack: 2,

--- a/cards/StartingHeroes/Shaman/9-hero.ts
+++ b/cards/StartingHeroes/Shaman/9-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 9,
 
 	armor: 0,

--- a/cards/StartingHeroes/Shaman/Totems/15-healing-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/15-healing-totem.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["totem"],
 	id: 15,
 
 	attack: 0,

--- a/cards/StartingHeroes/Shaman/Totems/16-searing-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/16-searing-totem.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["totem"],
 	id: 16,
 
 	attack: 1,

--- a/cards/StartingHeroes/Shaman/Totems/17-stoneclaw-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/17-stoneclaw-totem.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["totem"],
 	id: 17,
 
 	attack: 0,

--- a/cards/StartingHeroes/Shaman/Totems/18-strength-totem.ts
+++ b/cards/StartingHeroes/Shaman/Totems/18-strength-totem.ts
@@ -12,6 +12,7 @@ export const blueprint: Blueprint = {
 	classes: ["Shaman"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["totem"],
 	id: 18,
 
 	attack: 0,

--- a/cards/StartingHeroes/Warlock/11-hero.ts
+++ b/cards/StartingHeroes/Warlock/11-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warlock"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 11,
 
 	armor: 0,

--- a/cards/StartingHeroes/Warlock/121-heropower.ts
+++ b/cards/StartingHeroes/Warlock/121-heropower.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warlock"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 121,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Warlock/21-draconic-imp.ts
+++ b/cards/StartingHeroes/Warlock/21-draconic-imp.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warlock"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 21,
 
 	attack: 1,

--- a/cards/StartingHeroes/Warrior/117-heropower.ts
+++ b/cards/StartingHeroes/Warrior/117-heropower.ts
@@ -11,6 +11,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warrior"],
 	rarity: "Free",
 	collectible: false,
+	tags: [],
 	id: 117,
 
 	async heropower(owner, self) {

--- a/cards/StartingHeroes/Warrior/7-hero.ts
+++ b/cards/StartingHeroes/Warrior/7-hero.ts
@@ -10,6 +10,7 @@ export const blueprint: Blueprint = {
 	classes: ["Warrior"],
 	rarity: "Free",
 	collectible: false,
+	tags: ["starting_hero"],
 	id: 7,
 
 	armor: 0,

--- a/src/core/card.ts
+++ b/src/core/card.ts
@@ -441,7 +441,7 @@ export class Card {
 	 * @returns An array of cards that have any of the specified tags.
 	 */
 	static async allWithTags(tags: string[]): Promise<Card[]> {
-		return (await Card.all()).filter((c) =>
+		return (await Card.all(true)).filter((c) =>
 			tags.some((tag) => c.tags.includes(tag)),
 		);
 	}

--- a/src/core/card.ts
+++ b/src/core/card.ts
@@ -2077,8 +2077,17 @@ export class Card {
 		sb += this.colorFromRarity(name);
 
 		if (game.config.general.debug) {
+			sb += " (";
+
 			const idHex = (this.id + 1000).toString(16).repeat(6).slice(0, 6);
-			sb += ` (#<#${idHex}>${this.id}</#> @${this.coloredUUID()})`;
+			sb += `#<#${idHex}>${this.id}</#>`;
+			sb += ` @${this.coloredUUID()}`;
+
+			if (this.tags.length > 0) {
+				sb += ` <gray>[${this.tags.join(", ")}]</gray>`;
+			}
+
+			sb += ")";
 		}
 
 		if (this.hasStats()) {

--- a/src/core/card.ts
+++ b/src/core/card.ts
@@ -101,6 +101,13 @@ export class Card {
 	 */
 	keywords: { [key in CardKeyword]?: unknown } = {};
 
+	/**
+	 * Any tags that should be applied to the card.
+	 * Tags are used to group cards together. They should be lowercase.
+	 * E.g. "lackey"
+	 *
+	 * This can be queried like this: `Card.allWithTags(["lackey"]);`
+	 */
 	tags: string[] = [];
 
 	/**

--- a/src/core/card.ts
+++ b/src/core/card.ts
@@ -101,6 +101,8 @@ export class Card {
 	 */
 	keywords: { [key in CardKeyword]?: unknown } = {};
 
+	tags: string[] = [];
+
 	/**
 	 * The card's blueprint. This is the baseline of the card.
 	 */
@@ -430,6 +432,18 @@ export class Card {
 		}
 
 		return game.cards.filter((c) => c.collectible || include_uncollectible);
+	}
+
+	/**
+	 * Returns all cards that have at least one of the specified tags.
+	 *
+	 * @param tags An array of tags to filter the cards by.
+	 * @returns An array of cards that have any of the specified tags.
+	 */
+	static async allWithTags(tags: string[]): Promise<Card[]> {
+		return (await Card.all()).filter((c) =>
+			tags.some((tag) => c.tags.includes(tag)),
+		);
 	}
 
 	/**

--- a/src/core/functions/card.ts
+++ b/src/core/functions/card.ts
@@ -242,7 +242,11 @@ export const cardFunctions = {
 	},
 
 	/**
-	 * Returns the result of the galakrond formula
+	 * Returns the result of the galakrond formula:
+	 *
+	 * 1. Returns 1 if `invokeCount` is less than or equal to 2.
+	 * 2. Otherwise, returns 2 if `invokeCount` is less than or equal to 4.
+	 * 3. Otherwise, returns 4.
 	 *
 	 * @param invokeCount How many times that the card has been invoked.
 	 */
@@ -562,11 +566,11 @@ export const cardFunctions = {
 			success = true;
 		} else {
 			const match = /DIY (\d+)/.exec(card.name);
-			const fileName = match ? match[1] : "unknown";
+			const index = match ? match[1] : "unknown";
 
 			console.log(
 				"Hm. This card doesn't seem to do what it's supposed to do... Maybe you should try to fix it? The card is in: './cards/Examples/DIY/%s.ts'.",
-				fileName,
+				index,
 			);
 		}
 

--- a/src/core/functions/card.ts
+++ b/src/core/functions/card.ts
@@ -229,9 +229,13 @@ export const cardFunctions = {
 	 */
 	async getClasses(): Promise<CardClassNoNeutral[]> {
 		const cards = await Promise.all(
-			game.cardCollections.classes.map((heroId) =>
-				Card.create(heroId, game.player, true),
-			),
+			(await Card.allWithTags(["starting_hero"])).map(async (hero) => {
+				const unsuppress = game.event.suppress("CreateCard");
+				const card = await hero.imperfectCopy();
+				unsuppress();
+
+				return card;
+			}),
 		);
 
 		return cards.map((card) => card.classes[0]) as CardClassNoNeutral[];

--- a/src/core/functions/interact.ts
+++ b/src/core/functions/interact.ts
@@ -786,9 +786,14 @@ export const interactFunctions = {
 	 */
 	async printHand(player: Player): Promise<void> {
 		console.log("--- %s (%s)'s Hand ---", player.name, player.heroClass);
+
+		const debugInfo = game.config.general.debug
+			? "(<gray>Debug Info -></gray> #id @uuid <gray>[tags]</gray>) "
+			: "";
+
 		// Add the help message
 		console.log(
-			"([index] <cyan>{Cost}</cyan> <b>Name</b> <bright:green>[attack / health]</bright:green> <yellow>(type)</yellow>)\n",
+			`([index] <cyan>{Cost}</cyan> <b>Name</b> ${debugInfo}<bright:green>[attack / health]</bright:green> <yellow>(type)</yellow>)\n`,
 		);
 
 		for (const [index, card] of player.hand.entries()) {

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -19,11 +19,6 @@ import date from "date-and-time";
 import _ from "lodash";
 import { cardIds } from "../../cards/ids.js";
 
-const cardCollections = {
-	totems: [15, 16, 17, 18],
-	classes: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-};
-
 const attack = {
 	/**
 	 * Makes a minion or hero attack another minion or hero
@@ -1264,7 +1259,6 @@ export class Game {
 		},
 	};
 
-	cardCollections = cardCollections;
 	lodash = _;
 	cardIds = cardIds;
 

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -20,7 +20,6 @@ import _ from "lodash";
 import { cardIds } from "../../cards/ids.js";
 
 const cardCollections = {
-	lackeys: [24, 25, 26, 27, 28],
 	totems: [15, 16, 17, 18],
 	classes: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
 };

--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -833,9 +833,15 @@ export class Player {
 	async setToStartingHero(heroClass = this.heroClass): Promise<boolean> {
 		const heroCardId = (
 			await Promise.all(
-				game.cardCollections.classes.map(async (heroId) =>
-					Card.create(heroId, this, true),
-				),
+				(
+					await Card.allWithTags(["starting_hero"])
+				).map(async (hero) => {
+					const unsuppress = game.event.suppress("CreateCard");
+					const card = await hero.imperfectCopy();
+					unsuppress();
+
+					return card;
+				}),
 			)
 		).find((card) => card.classes.includes(heroClass))?.id;
 

--- a/src/core/player.ts
+++ b/src/core/player.ts
@@ -1203,20 +1203,17 @@ export class Player {
 	 * @returns Success
 	 */
 	async invoke(): Promise<boolean> {
-		// Find the card in player's deck/hand/hero that begins with "Galakrond, the "
-		const deckGalakrond = this.deck.find((c) =>
-			c.name.startsWith("Galakrond, the "),
+		const isCurrentlyGalakrond = this.hero.tags.includes("galakrond");
+
+		const hasGalakrondInDeck = this.deck.find((c) =>
+			c.tags.includes("galakrond"),
 		);
 
-		const handGalakrond = this.hand.find((c) =>
-			c.name.startsWith("Galakrond, the "),
+		const hasGalakrondInHand = this.hand.find((c) =>
+			c.tags.includes("galakrond"),
 		);
 
-		if (
-			!deckGalakrond &&
-			!handGalakrond &&
-			!this.hero.name.startsWith("Galakrond, the ")
-		) {
+		if (!hasGalakrondInDeck && !hasGalakrondInHand && !isCurrentlyGalakrond) {
 			return false;
 		}
 
@@ -1232,12 +1229,12 @@ export class Player {
 			await card.activate("invoke");
 		}
 
-		if (this.hero.name.startsWith("Galakrond, the ")) {
+		if (isCurrentlyGalakrond) {
 			await this.hero.heropower?.activate("cast");
-		} else if (deckGalakrond) {
-			await deckGalakrond.heropower?.activate("cast");
-		} else if (handGalakrond) {
-			await handGalakrond.heropower?.activate("cast");
+		} else if (hasGalakrondInDeck) {
+			await hasGalakrondInDeck.heropower?.activate("cast");
+		} else if (hasGalakrondInHand) {
+			await hasGalakrondInHand.heropower?.activate("cast");
 		}
 
 		return true;
@@ -1380,9 +1377,7 @@ export class Player {
 			return;
 		}
 
-		const list = (await Card.all(true)).filter((card) =>
-			/DIY \d+/.test(card.name),
-		);
+		const list = await Card.allWithTags(["diy"]);
 
 		const card = game.lodash.sample(list);
 		if (!card) {

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -219,6 +219,8 @@ export type Blueprint = {
 	classes: CardClass[];
 	/** The rarity of the card. This doesn't really do much in this game since there isn't any lootbox mechanics here. Examples of rarities: "Legendary", "Epic", "Free", etc... */
 	rarity: CardRarity;
+	/** The tags of the card. */
+	tags: string[];
 	/** If the card should be allowed in decks / card pools. */
 	collectible: boolean;
 	/**

--- a/tools/cardcreator/class.ts
+++ b/tools/cardcreator/class.ts
@@ -59,6 +59,7 @@ export async function main(
 		classes: [className] as CardClass[],
 		rarity: "Free" as CardRarity,
 		collectible: false,
+		tags: ["starting_hero"],
 		// This will be overwritten by the library
 		id: 0,
 
@@ -74,6 +75,7 @@ export async function main(
 		classes: [className] as CardClass[],
 		rarity: "Free" as CardRarity,
 		collectible: false,
+		tags: [],
 		// This will be overwritten by the library
 		id: 0,
 	};

--- a/tools/cardcreator/custom.ts
+++ b/tools/cardcreator/custom.ts
@@ -119,6 +119,7 @@ async function common(): Promise<BlueprintWithOptional> {
 		runes,
 		keywords: realKeywords,
 		collectible: true,
+		tags: [],
 		id: 0,
 	};
 }

--- a/tools/cardcreator/vanilla.ts
+++ b/tools/cardcreator/vanilla.ts
@@ -98,6 +98,7 @@ export async function create(
 		classes: [cardClass],
 		rarity,
 		collectible,
+		tags: [],
 		id: 0,
 	};
 


### PR DESCRIPTION
Closes #368

- [x] Add `tags` field to the 100 remaining blueprints.
- [x] Replace `cardCollections`.
- [x] Make `DIY` tag.
- [x] Make `galakrond` tag.
- [x] Add tags to card creators.
- [x] Consider adding them to Card.view / Card.readable